### PR TITLE
first pass at code cleanup & static code analysis warnings

### DIFF
--- a/src/Roadkill.Api.Common/Request/PageRequest.cs
+++ b/src/Roadkill.Api.Common/Request/PageRequest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel.DataAnnotations;
-using AutoMapper;
 
 
 namespace Roadkill.Api.Common.Request

--- a/src/Roadkill.Api.Common/Request/UserRequest.cs
+++ b/src/Roadkill.Api.Common/Request/UserRequest.cs
@@ -1,5 +1,3 @@
-using AutoMapper;
-
 namespace Roadkill.Api.Common.Request
 {
 	public class UserRequest

--- a/src/Roadkill.Api/Authorization/JWT/JwtTokenService.cs
+++ b/src/Roadkill.Api/Authorization/JWT/JwtTokenService.cs
@@ -56,7 +56,7 @@ namespace Roadkill.Api.Authorization.JWT
 						if (principal != null && securityToken != null)
 							return userRefreshToken;
 					}
-					catch (Exception e)
+					catch (Exception)
 					{
 						return null;
 					}
@@ -70,10 +70,10 @@ namespace Roadkill.Api.Authorization.JWT
 		{
 			try
 			{
-				ClaimsPrincipal principal = _tokenHandler.ValidateToken(jwtToken, _tokenValidationParameters, out SecurityToken securityToken);
+				_ = _tokenHandler.ValidateToken(jwtToken, _tokenValidationParameters, out SecurityToken securityToken);
 				return securityToken as JwtSecurityToken;
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
 				return null;
 			}
@@ -89,10 +89,10 @@ namespace Roadkill.Api.Authorization.JWT
 		{
 			var allClaims = new List<Claim>(existingClaims)
 			{
-				new Claim(ClaimTypes.Name, email)
+				new(ClaimTypes.Name, email)
 			};
 
-			var key = Encoding.ASCII.GetBytes(_jwtSettings.Password);
+			byte[] key = Encoding.ASCII.GetBytes(_jwtSettings.Password);
 			var symmetricSecurityKey = new SymmetricSecurityKey(key);
 
 			var tokenDescriptor = new SecurityTokenDescriptor

--- a/src/Roadkill.Api/Authorization/JWT/RoadkillClaims.cs
+++ b/src/Roadkill.Api/Authorization/JWT/RoadkillClaims.cs
@@ -5,7 +5,7 @@ namespace Roadkill.Api.Authorization.JWT
 {
 	public static class RoadkillClaims
 	{
-		public static Claim AdminClaim => new Claim(ClaimTypes.Role, AdminRoleDefinition.Name);
-		public static Claim EditorClaim => new Claim(ClaimTypes.Role, EditorRoleDefinition.Name);
+		public static Claim AdminClaim => new(ClaimTypes.Role, AdminRoleDefinition.Name);
+		public static Claim EditorClaim => new(ClaimTypes.Role, EditorRoleDefinition.Name);
 	}
 }

--- a/src/Roadkill.Api/Authorization/Roles/EditorRoleDefinition.cs
+++ b/src/Roadkill.Api/Authorization/Roles/EditorRoleDefinition.cs
@@ -8,7 +8,7 @@ namespace Roadkill.Api.Authorization.Roles
 		public const string Name = "editor";
 		string IUserRoleDefinition.Name => Name;
 
-		private readonly List<string> _availablePolicies = new List<string>()
+		private readonly List<string> _availablePolicies = new()
 		{
 			PolicyNames.AddPage,
 			PolicyNames.UpdatePage

--- a/src/Roadkill.Api/Controllers/AuthorizationController.cs
+++ b/src/Roadkill.Api/Controllers/AuthorizationController.cs
@@ -77,7 +77,7 @@ namespace Roadkill.Api.Controllers
 			if (userRefreshToken != null)
 			{
 				JwtSecurityToken jwtSecurityToken = _jwtTokenService.GetJwtSecurityToken(userRefreshToken.JwtToken);
-				List<Claim> existingClaims = jwtSecurityToken.Claims.ToList();
+				var existingClaims = jwtSecurityToken.Claims.ToList();
 				string email = existingClaims.First(x => x.Type == ClaimTypes.Name).Value;
 
 				string refreshToken = userRefreshToken.RefreshToken;

--- a/src/Roadkill.Api/Controllers/EmailController.cs
+++ b/src/Roadkill.Api/Controllers/EmailController.cs
@@ -1,10 +1,8 @@
 using System.Threading.Tasks;
 using Asp.Versioning;
 using MailKit;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MimeKit;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.Roles;
 using Roadkill.Core.Settings;
 

--- a/src/Roadkill.Api/Controllers/ExportController.cs
+++ b/src/Roadkill.Api/Controllers/ExportController.cs
@@ -4,9 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Asp.Versioning;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.Roles;
 using Roadkill.Core.Entities;
 using Roadkill.Core.Repositories;
@@ -31,14 +29,12 @@ namespace Roadkill.Api.Controllers
 		public async Task<ActionResult<string>> ExportPagesToXml()
 		{
 			IEnumerable<Page> allPages = await _pageRepository.AllPagesAsync();
-			XmlSerializer serializer = new XmlSerializer(typeof(List<Page>));
+			var serializer = new XmlSerializer(typeof(List<Page>));
 
-			StringBuilder builder = new StringBuilder();
-			using (StringWriter writer = new StringWriter(builder))
-			{
-				serializer.Serialize(writer, allPages);
-				return Ok(builder.ToString());
-			}
+			var builder = new StringBuilder();
+			using var writer = new StringWriter(builder);
+			serializer.Serialize(writer, allPages);
+			return Ok(builder.ToString());
 		}
 
 		[HttpPost]

--- a/src/Roadkill.Api/Controllers/FileController.cs
+++ b/src/Roadkill.Api/Controllers/FileController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.Roles;
 
 namespace Roadkill.Api.Controllers

--- a/src/Roadkill.Api/Controllers/InstallController.cs
+++ b/src/Roadkill.Api/Controllers/InstallController.cs
@@ -1,10 +1,8 @@
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.JWT;
 using Roadkill.Core.Entities.Authorization;
 

--- a/src/Roadkill.Api/Controllers/SearchController.cs
+++ b/src/Roadkill.Api/Controllers/SearchController.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.Roles;
 using Roadkill.Api.Common.Request;
 using Roadkill.Api.Common.Response;

--- a/src/Roadkill.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Roadkill.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Roadkill.Api.Extensions
 						})
 					};
 
-					var json = JsonConvert.SerializeObject(statusObject);
+					string json = JsonConvert.SerializeObject(statusObject);
 					context.Response.ContentType = MediaTypeNames.Application.Json;
 					await context.Response.WriteAsync(json);
 				}

--- a/src/Roadkill.Api/Middleware/JsonExceptionMiddleware.cs
+++ b/src/Roadkill.Api/Middleware/JsonExceptionMiddleware.cs
@@ -44,11 +44,9 @@ namespace Roadkill.Api.Middleware
 
 			context.Response.ContentType = "application/json";
 
-			using (var writer = new StreamWriter(context.Response.Body))
-			{
-				new JsonSerializer().Serialize(writer, error);
-				await writer.FlushAsync().ConfigureAwait(false);
-			}
+			using var writer = new StreamWriter(context.Response.Body);
+			new JsonSerializer().Serialize(writer, error);
+			await writer.FlushAsync().ConfigureAwait(false);
 		}
 
 		private class ErrorDetails

--- a/src/Roadkill.Api/ObjectConverters/PageObjectsConverter.cs
+++ b/src/Roadkill.Api/ObjectConverters/PageObjectsConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using AutoMapper;
@@ -40,7 +40,7 @@ namespace Roadkill.Api.ObjectConverters
 
 		private static IEnumerable<string> TagsToList(string csvTags)
 		{
-			List<string> tagList = new List<string>();
+			var tagList = new List<string>();
 			char delimiter = ',';
 
 			if (!string.IsNullOrEmpty(csvTags))
@@ -87,7 +87,7 @@ namespace Roadkill.Api.ObjectConverters
 			title = Regex.Replace(title, @"[\s-]+", " ").Trim();
 
 			// If it's over 30 chars, take the first 30.
-			title = title.Substring(0, title.Length <= 75 ? title.Length : 75).Trim();
+			title = title[..(title.Length <= 75 ? title.Length : 75)].Trim();
 
 			// hyphenate spaces
 			title = Regex.Replace(title, @"\s", "-");

--- a/src/Roadkill.Api/ObjectConverters/UserObjectsConverter.cs
+++ b/src/Roadkill.Api/ObjectConverters/UserObjectsConverter.cs
@@ -1,5 +1,4 @@
 using AutoMapper;
-using Roadkill.Api.Common.Request;
 using Roadkill.Api.Common.Response;
 using Roadkill.Core.Entities.Authorization;
 

--- a/src/Roadkill.Api/Program.cs
+++ b/src/Roadkill.Api/Program.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Serilog;

--- a/src/Roadkill.Api/Startup.cs
+++ b/src/Roadkill.Api/Startup.cs
@@ -62,11 +62,6 @@ namespace Roadkill.Api
 				.AddCheck<MartenHealthCheck>("marten");
 		}
 
-		public void ConfigureTestServices(IServiceCollection services)
-		{
-			// Configure services for Test environment
-		}
-
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		// You can add these parameters to this method: IHostingEnvironment env, ILoggerFactory loggerFactory
 		public override void Configure(IApplicationBuilder app)

--- a/src/Roadkill.Core/Entities/Authorization/UserRefreshToken.cs
+++ b/src/Roadkill.Core/Entities/Authorization/UserRefreshToken.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Security.Claims;
 using Marten.Schema;
 
 namespace Roadkill.Core.Entities.Authorization

--- a/src/Roadkill.Core/Entities/Salt.cs
+++ b/src/Roadkill.Core/Entities/Salt.cs
@@ -13,7 +13,7 @@ namespace Roadkill.Core.Entities
 	/// </remarks>
 	public class Salt
 	{
-		private static readonly Random _random = new Random();
+		private static readonly Random _random = new();
 
 		public string Value { get; }
 

--- a/src/Roadkill.Core/Entities/SearchablePage.cs
+++ b/src/Roadkill.Core/Entities/SearchablePage.cs
@@ -1,5 +1,4 @@
 using System;
-using Elastic.Clients.Elasticsearch;
 
 namespace Roadkill.Core.Entities
 {

--- a/src/Roadkill.Core/Repositories/PageRepository.cs
+++ b/src/Roadkill.Core/Repositories/PageRepository.cs
@@ -46,118 +46,96 @@ namespace Roadkill.Core.Repositories
 		{
 			page.Id = 0; // reset so it's autoincremented
 
-			using (var session = _store.LightweightSession())
-			{
-				session.Store(page);
+			await using var session = _store.LightweightSession();
+			session.Store(page);
 
-				await session.SaveChangesAsync();
-				return page;
-			}
+			await session.SaveChangesAsync();
+			return page;
 		}
 
 		public async Task<IEnumerable<Page>> AllPagesAsync()
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<Page>()
-					.ToListAsync();
-			}
+			await using var session = _store.QuerySession();
+			return await session
+				.Query<Page>()
+				.ToListAsync();
 		}
 
 		public async Task<IEnumerable<string>> AllTagsAsync()
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<Page>()
-					.Select(x => x.Tags)
-					.ToListAsync();
-			}
+			await using var session = _store.QuerySession();
+			return await session
+				.Query<Page>()
+				.Select(x => x.Tags)
+				.ToListAsync();
 		}
 
 		public async Task DeletePageAsync(int pageId)
 		{
-			using (var session = _store.LightweightSession())
-			{
-				session.Delete<Page>(pageId);
-				await session.SaveChangesAsync();
-			}
+			await using var session = _store.LightweightSession();
+			session.Delete<Page>(pageId);
+			await session.SaveChangesAsync();
 		}
 
 		public async Task DeleteAllPagesAsync()
 		{
-			using (var session = _store.LightweightSession())
-			{
-				session.DeleteWhere<Page>(x => true);
-				session.DeleteWhere<PageVersion>(x => true);
+			await using var session = _store.LightweightSession();
+			session.DeleteWhere<Page>(x => true);
+			session.DeleteWhere<PageVersion>(x => true);
 
-				await session.SaveChangesAsync();
-			}
+			await session.SaveChangesAsync();
 		}
 
 		public async Task<IEnumerable<Page>> FindPagesCreatedByAsync(string username)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<Page>()
-					.Where(x => x.CreatedBy.Equals(username, StringComparison.CurrentCultureIgnoreCase))
-					.ToListAsync();
-			}
+			await using var session = _store.QuerySession();
+			return await session
+				.Query<Page>()
+				.Where(x => x.CreatedBy.Equals(username, StringComparison.CurrentCultureIgnoreCase))
+				.ToListAsync();
 		}
 
 		public async Task<IEnumerable<Page>> FindPagesLastModifiedByAsync(string username)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<Page>()
-					.Where(x => x.LastModifiedBy.Equals(username, StringComparison.CurrentCultureIgnoreCase))
-					.ToListAsync();
-			}
+			await using var session = _store.QuerySession();
+			return await session
+				.Query<Page>()
+				.Where(x => x.LastModifiedBy.Equals(username, StringComparison.CurrentCultureIgnoreCase))
+				.ToListAsync();
 		}
 
 		public async Task<IEnumerable<Page>> FindPagesContainingTagAsync(string tag)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<Page>()
-					.Where(x => x.Tags.Contains(tag))
-					.ToListAsync();
-			}
+			await using var session = _store.QuerySession();
+			return await session
+				.Query<Page>()
+				.Where(x => x.Tags.Contains(tag))
+				.ToListAsync();
 		}
 
 		public async Task<Page> GetPageByIdAsync(int id)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<Page>()
-					.FirstOrDefaultAsync(x => x.Id == id);
-			}
+			await using var session = _store.QuerySession();
+			return await session
+				.Query<Page>()
+				.FirstOrDefaultAsync(x => x.Id == id);
 		}
 
 		public async Task<Page> GetPageByTitleAsync(string title)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<Page>()
-					.FirstOrDefaultAsync(x => x.Title == title);
-			}
+			await using var session = _store.QuerySession();
+			return await session
+				.Query<Page>()
+				.FirstOrDefaultAsync(x => x.Title == title);
 		}
 
 		public async Task<Page> UpdateExistingAsync(Page page)
 		{
-			using (var session = _store.LightweightSession())
-			{
-				session.Update(page);
+			await using var session = _store.LightweightSession();
+			session.Update(page);
 
-				await session.SaveChangesAsync();
-				return page;
-			}
+			await session.SaveChangesAsync();
+			return page;
 		}
 
 		public void Wipe()

--- a/src/Roadkill.Core/Repositories/PageVersionRepository.cs
+++ b/src/Roadkill.Core/Repositories/PageVersionRepository.cs
@@ -38,100 +38,84 @@ namespace Roadkill.Core.Repositories
 
 		public async Task<PageVersion> AddNewVersionAsync(int pageId, string text, string author, DateTime? dateTime = null)
 		{
-			using (var session = _store.LightweightSession())
+			using var session = _store.LightweightSession();
+			if (dateTime == null)
 			{
-				if (dateTime == null)
-				{
-					dateTime = DateTime.UtcNow;
-				}
-
-				var pageVersion = new PageVersion
-				{
-					Id = Guid.NewGuid(),
-					Author = author,
-					DateTime = dateTime.Value,
-					PageId = pageId,
-					Text = text
-				};
-				session.Store(pageVersion);
-
-				await session.SaveChangesAsync();
-				return pageVersion;
+				dateTime = DateTime.UtcNow;
 			}
+
+			var pageVersion = new PageVersion
+			{
+				Id = Guid.NewGuid(),
+				Author = author,
+				DateTime = dateTime.Value,
+				PageId = pageId,
+				Text = text
+			};
+			session.Store(pageVersion);
+
+			await session.SaveChangesAsync();
+			return pageVersion;
 		}
 
 		public async Task<IEnumerable<PageVersion>> AllVersionsAsync()
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<PageVersion>()
-					.ToListAsync();
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<PageVersion>()
+				.ToListAsync();
 		}
 
 		public async Task DeleteVersionAsync(Guid id)
 		{
-			using (var session = _store.OpenSession())
-			{
-				session.Delete<PageVersion>(id);
-				session.DeleteWhere<PageVersion>(x => x.Id == id);
-				await session.SaveChangesAsync();
-			}
+			using var session = _store.LightweightSession();
+			session.Delete<PageVersion>(id);
+			session.DeleteWhere<PageVersion>(x => x.Id == id);
+			await session.SaveChangesAsync();
 		}
 
 		public async Task<IEnumerable<PageVersion>> FindPageVersionsByPageIdAsync(int pageId)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<PageVersion>()
-					.Where(x => x.PageId == pageId)
-					.OrderByDescending(x => x.DateTime)
-					.ToListAsync();
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<PageVersion>()
+				.Where(x => x.PageId == pageId)
+				.OrderByDescending(x => x.DateTime)
+				.ToListAsync();
 		}
 
 		public async Task<IEnumerable<PageVersion>> FindPageVersionsByAuthorAsync(string username)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<PageVersion>()
-					.Where(x => x.Author.Equals(username, StringComparison.CurrentCultureIgnoreCase))
-					.OrderByDescending(x => x.DateTime)
-					.ToListAsync();
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<PageVersion>()
+				.Where(x => x.Author.Equals(username, StringComparison.CurrentCultureIgnoreCase))
+				.OrderByDescending(x => x.DateTime)
+				.ToListAsync();
 		}
 
 		public async Task<PageVersion> GetLatestVersionAsync(int pageId)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<PageVersion>()
-					.OrderByDescending(x => x.DateTime)
-					.FirstOrDefaultAsync(x => x.PageId == pageId);
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<PageVersion>()
+				.OrderByDescending(x => x.DateTime)
+				.FirstOrDefaultAsync(x => x.PageId == pageId);
 		}
 
 		public async Task<PageVersion> GetByIdAsync(Guid id)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<PageVersion>()
-					.FirstOrDefaultAsync(x => x.Id == id);
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<PageVersion>()
+				.FirstOrDefaultAsync(x => x.Id == id);
 		}
 
 		public async Task UpdateExistingVersionAsync(PageVersion version)
 		{
-			using (var session = _store.LightweightSession())
-			{
-				session.Store(version);
-				await session.SaveChangesAsync();
-			}
+			using var session = _store.LightweightSession();
+			session.Store(version);
+			await session.SaveChangesAsync();
 		}
 
 		public void Wipe()

--- a/src/Roadkill.Core/Repositories/UserRefreshTokenRepository.cs
+++ b/src/Roadkill.Core/Repositories/UserRefreshTokenRepository.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Marten;
 using Roadkill.Core.Entities.Authorization;
@@ -26,49 +24,41 @@ namespace Roadkill.Core.Repositories
 
 		public async Task<UserRefreshToken> GetRefreshToken(string refreshToken)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<UserRefreshToken>()
-					.FirstOrDefaultAsync(x => x.RefreshToken == refreshToken);
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<UserRefreshToken>()
+				.FirstOrDefaultAsync(x => x.RefreshToken == refreshToken);
 		}
 
 		public async Task<UserRefreshToken> AddRefreshToken(string jwtId, string refreshToken, string email, string ipAddress)
 		{
-			using (var session = _store.LightweightSession())
+			using var session = _store.LightweightSession();
+			var token = new UserRefreshToken()
 			{
-				var token = new UserRefreshToken()
-				{
-					JwtToken = jwtId,
-					RefreshToken = refreshToken,
-					CreationDate = DateTime.UtcNow,
-					IpAddress = ipAddress,
-					Email = email
-				};
-				session.Store(token);
-				await session.SaveChangesAsync();
+				JwtToken = jwtId,
+				RefreshToken = refreshToken,
+				CreationDate = DateTime.UtcNow,
+				IpAddress = ipAddress,
+				Email = email
+			};
+			session.Store(token);
+			await session.SaveChangesAsync();
 
-				return token;
-			}
+			return token;
 		}
 
 		public async Task DeleteRefreshToken(string refreshToken)
 		{
-			using (var session = _store.LightweightSession())
-			{
-				session.DeleteWhere<UserRefreshToken>(x => x.RefreshToken == refreshToken);
-				await session.SaveChangesAsync();
-			}
+			using var session = _store.LightweightSession();
+			session.DeleteWhere<UserRefreshToken>(x => x.RefreshToken == refreshToken);
+			await session.SaveChangesAsync();
 		}
 
 		public async Task DeleteRefreshTokens(string email)
 		{
-			using (var session = _store.LightweightSession())
-			{
-				session.DeleteWhere<UserRefreshToken>(x => x.Email== email);
-				await session.SaveChangesAsync();
-			}
+			using var session = _store.LightweightSession();
+			session.DeleteWhere<UserRefreshToken>(x => x.Email == email);
+			await session.SaveChangesAsync();
 		}
 	}
 }

--- a/src/Roadkill.Core/Repositories/UserRepository.cs
+++ b/src/Roadkill.Core/Repositories/UserRepository.cs
@@ -47,136 +47,110 @@ namespace Roadkill.Core.Repositories
 
 		public async Task DeleteAllUsersAsync()
 		{
-			using (var session = _store.LightweightSession())
-			{
-				session.DeleteWhere<User>(x => true);
-				await session.SaveChangesAsync();
-			}
+			using var session = _store.LightweightSession();
+			session.DeleteWhere<User>(x => true);
+			await session.SaveChangesAsync();
 		}
 
 		public async Task DeleteUserAsync(User user)
 		{
-			using (var session = _store.LightweightSession())
-			{
-				session.DeleteWhere<User>(x => x.Id == user.Id);
-				await session.SaveChangesAsync();
-			}
+			using var session = _store.LightweightSession();
+			session.DeleteWhere<User>(x => x.Id == user.Id);
+			await session.SaveChangesAsync();
 		}
 
 		public async Task<IEnumerable<User>> FindAllEditorsAsync()
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<User>()
-					.Where(x => x.IsEditor)
-					.ToListAsync();
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<User>()
+				.Where(x => x.IsEditor)
+				.ToListAsync();
 		}
 
 		public async Task<IEnumerable<User>> FindAllAdminsAsync()
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<User>()
-					.Where(x => x.IsAdmin)
-					.ToListAsync();
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<User>()
+				.Where(x => x.IsAdmin)
+				.ToListAsync();
 		}
 
 		public async Task<User> GetAdminByIdAsync(Guid id)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<User>()
-					.FirstOrDefaultAsync(x => x.Id == id);
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<User>()
+				.FirstOrDefaultAsync(x => x.Id == id);
 		}
 
 		public async Task<User> GetUserByActivationKeyAsync(string key)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<User>()
-					.FirstOrDefaultAsync(x => x.ActivationKey == key);
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<User>()
+				.FirstOrDefaultAsync(x => x.ActivationKey == key);
 		}
 
 		public async Task<User> GetEditorByIdAsync(Guid id)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<User>()
-					.FirstOrDefaultAsync(x => x.Id == id && x.IsEditor);
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<User>()
+				.FirstOrDefaultAsync(x => x.Id == id && x.IsEditor);
 		}
 
 		public async Task<User> GetUserByEmailAsync(string email, bool? isActivated = null)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<User>()
-					.FirstOrDefaultAsync(x => x.Email == email && x.IsActivated == isActivated);
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<User>()
+				.FirstOrDefaultAsync(x => x.Email == email && x.IsActivated == isActivated);
 		}
 
 		public async Task<User> GetUserByIdAsync(Guid id, bool? isActivated = null)
 		{
-			using (var session = _store.QuerySession())
+			using var session = _store.QuerySession();
+			// default to searching for activated users
+			if (isActivated is null)
 			{
-				// default to searching for activated users
-				if (isActivated is null)
-				{
-					isActivated = true;
-				}
-				return await session
-					.Query<User>()
-					.FirstOrDefaultAsync(x => x.Id == id && x.IsActivated == isActivated);
+				isActivated = true;
 			}
+			return await session
+				.Query<User>()
+				.FirstOrDefaultAsync(x => x.Id == id && x.IsActivated == isActivated);
 		}
 
 		public async Task<User> GetUserByPasswordResetKeyAsync(string key)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<User>()
-					.FirstOrDefaultAsync(x => x.PasswordResetKey == key);
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<User>()
+				.FirstOrDefaultAsync(x => x.PasswordResetKey == key);
 		}
 
 		public async Task<User> GetUserByUsernameAsync(string username)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<User>()
-					.FirstOrDefaultAsync(x => x.Username == username);
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<User>()
+				.FirstOrDefaultAsync(x => x.Username == username);
 		}
 
 		public async Task<User> GetUserByUsernameOrEmailAsync(string username, string email)
 		{
-			using (var session = _store.QuerySession())
-			{
-				return await session
-					.Query<User>()
-					.FirstOrDefaultAsync(x => x.Username == username || x.Email == email);
-			}
+			using var session = _store.QuerySession();
+			return await session
+				.Query<User>()
+				.FirstOrDefaultAsync(x => x.Username == username || x.Email == email);
 		}
 
 		public async Task SaveOrUpdateUserAsync(User user)
 		{
-			using (var session = _store.LightweightSession())
-			{
-				session.Store(user);
-				await session.SaveChangesAsync();
-			}
+			using var session = _store.LightweightSession();
+			session.Store(user);
+			await session.SaveChangesAsync();
 		}
 
 		public void Wipe()

--- a/src/Roadkill.Core/Search/Adapters/PostgresSearchAdapter.cs
+++ b/src/Roadkill.Core/Search/Adapters/PostgresSearchAdapter.cs
@@ -29,36 +29,30 @@ namespace Roadkill.Core.Search.Adapters
 
 		public async Task<bool> Add(SearchablePage page)
 		{
-			using (var session = _documentStore.LightweightSession())
-			{
-				session.Store(page);
+			using var session = _documentStore.LightweightSession();
+			session.Store(page);
 
-				await session.SaveChangesAsync();
-				return true;
-			}
+			await session.SaveChangesAsync();
+			return true;
 		}
 
 		public async Task<bool> Update(SearchablePage page)
 		{
-			using (var session = _documentStore.LightweightSession())
-			{
-				session.Delete<SearchablePage>(page.Id);
-				session.Store(page);
+			using var session = _documentStore.LightweightSession();
+			session.Delete<SearchablePage>(page.Id);
+			session.Store(page);
 
-				await session.SaveChangesAsync();
-				return true;
-			}
+			await session.SaveChangesAsync();
+			return true;
 		}
 
 		public async Task RecreateIndex()
 		{
-			using (var session = _documentStore.LightweightSession())
-			{
-				session.DeleteWhere<SearchablePage>(x => true);
+			using var session = _documentStore.LightweightSession();
+			session.DeleteWhere<SearchablePage>(x => true);
 
-				// TODO: add all pages back in
-				await session.SaveChangesAsync();
-			}
+			// TODO: add all pages back in
+			await session.SaveChangesAsync();
 		}
 
 		public async Task<IEnumerable<SearchablePage>> Find(string query)
@@ -66,41 +60,39 @@ namespace Roadkill.Core.Search.Adapters
 			var p = new SearchQueryParser();
 			ParsedQueryResult queryResult = p.ParseQuery(query);
 
-			using (var session = _documentStore.QuerySession())
+			using var session = _documentStore.QuerySession();
+			var martenQuery = session.Query<SearchablePage>().Where(x => true);
+
+			if (!string.IsNullOrEmpty(queryResult.TextWithoutFields))
 			{
-				var martenQuery = session.Query<SearchablePage>().Where(x => true);
-
-				if (!string.IsNullOrEmpty(queryResult.TextWithoutFields))
-				{
-					martenQuery = martenQuery.Where(x => x.PlainTextSearch(queryResult.TextWithoutFields));
-				}
-
-				string title = queryResult.GetFieldValue("title");
-				if (!string.IsNullOrEmpty(title))
-				{
-					martenQuery = martenQuery.Where(x => x.Title.PlainTextSearch(title));
-				}
-
-				string tags = queryResult.GetFieldValue("tags");
-				if (!string.IsNullOrEmpty(tags))
-				{
-					martenQuery = martenQuery.Where(x => x.PlainTextSearch(tags));
-				}
-
-				string pageId = queryResult.GetFieldValue("pageId");
-				if (!string.IsNullOrEmpty(pageId))
-				{
-					martenQuery = martenQuery.Where(x => x.PageId.PlainTextSearch(pageId));
-				}
-
-				string author = queryResult.GetFieldValue("author");
-				if (!string.IsNullOrEmpty(pageId))
-				{
-					martenQuery = martenQuery.Where(x => x.Author.PlainTextSearch(author));
-				}
-
-				return await martenQuery.ToListAsync();
+				martenQuery = martenQuery.Where(x => x.PlainTextSearch(queryResult.TextWithoutFields));
 			}
+
+			string title = queryResult.GetFieldValue("title");
+			if (!string.IsNullOrEmpty(title))
+			{
+				martenQuery = martenQuery.Where(x => x.Title.PlainTextSearch(title));
+			}
+
+			string tags = queryResult.GetFieldValue("tags");
+			if (!string.IsNullOrEmpty(tags))
+			{
+				martenQuery = martenQuery.Where(x => x.PlainTextSearch(tags));
+			}
+
+			string pageId = queryResult.GetFieldValue("pageId");
+			if (!string.IsNullOrEmpty(pageId))
+			{
+				martenQuery = martenQuery.Where(x => x.PageId.PlainTextSearch(pageId));
+			}
+
+			string author = queryResult.GetFieldValue("author");
+			if (!string.IsNullOrEmpty(pageId))
+			{
+				martenQuery = martenQuery.Where(x => x.Author.PlainTextSearch(author));
+			}
+
+			return await martenQuery.ToListAsync();
 		}
 	}
 }

--- a/src/Roadkill.Core/Search/Parsers/SearchQueryParser.cs
+++ b/src/Roadkill.Core/Search/Parsers/SearchQueryParser.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Sprache;
 
 namespace Roadkill.Core.Search.Parsers
 {
@@ -15,7 +14,7 @@ namespace Roadkill.Core.Search.Parsers
 		// Gold and ANTLR parsers to integrate in future:
 		// https://github.com/yetanotherchris/spruce/blob/master/Spruce.Core/Search/Grammar/spruce.grm
 		// https://github.com/lucastorri/query-parser/blob/master/antlr4/Query.g4
-		private static readonly Regex _parserRegex = new Regex(@"(?<name>\w+?):(?<value>""[^""]+""|[\w]+)", RegexOptions.Compiled);
+		private static readonly Regex _parserRegex = new(@"(?<name>\w+?):(?<value>""[^""]+""|[\w]+)", RegexOptions.Compiled);
 
 		public ParsedQueryResult ParseQuery(string queryText)
 		{

--- a/src/Roadkill.Tests.Integration/Api/Controllers/AuthorizationControllerTests.cs
+++ b/src/Roadkill.Tests.Integration/Api/Controllers/AuthorizationControllerTests.cs
@@ -44,14 +44,12 @@ namespace Roadkill.Tests.Integration.Api.Controllers
 			string json = JsonConvert.SerializeObject(data);
 			var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
 
-			using (var response = await _httpClient.PostAsync(requestUri, stringContent))
-			{
-				response.StatusCode.ShouldBe(statusCode, response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
-				var content = await response.Content.ReadAsStringAsync();
+			using var response = await _httpClient.PostAsync(requestUri, stringContent);
+			response.StatusCode.ShouldBe(statusCode, response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+			var content = await response.Content.ReadAsStringAsync();
 
-				content.ShouldNotBeNull();
-				return response;
-			}
+			content.ShouldNotBeNull();
+			return response;
 		}
 	}
 }

--- a/src/Roadkill.Tests.Integration/Api/Controllers/AuthorizationPolicyTests.cs
+++ b/src/Roadkill.Tests.Integration/Api/Controllers/AuthorizationPolicyTests.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Roadkill.Api.Common.Request;
 using Roadkill.Api.Common.Response;
@@ -133,7 +130,7 @@ namespace Roadkill.Tests.Integration.Api.Controllers
 
 			var response = await _httpClient.PostAsync(requestUri, stringContent);
 			response.StatusCode.ShouldBe(statusCode, response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
-			var content = await response.Content.ReadAsStringAsync();
+			string content = await response.Content.ReadAsStringAsync();
 
 			content.ShouldNotBeNull();
 			return response;

--- a/src/Roadkill.Tests.Integration/Api/Controllers/IntegrationTestsWebFactory.cs
+++ b/src/Roadkill.Tests.Integration/Api/Controllers/IntegrationTestsWebFactory.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Claims;
 using Marten;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
@@ -11,9 +10,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.TestPlatform.Common;
 using Roadkill.Api;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.JWT;
 using Roadkill.Core.Entities;
 using Roadkill.Core.Entities.Authorization;
@@ -23,7 +20,7 @@ namespace Roadkill.Tests.Integration.Api.Controllers
 {
 	public class IntegrationTestsWebFactory : WebApplicationFactory<Startup>
 	{
-		public static Dictionary<string, string> TestConfigValues = new Dictionary<string, string>
+		public static Dictionary<string, string> TestConfigValues = new()
 		{
 			{ "Postgres:ConnectionString", "host=localhost;port=5432;database=postgres;username=roadkill;password=roadkill;" },
 			{ "Smtp:Host", "smtp.gmail.com" },

--- a/src/Roadkill.Tests.Integration/Api/Controllers/MartenAspIdentityLoadTests.cs
+++ b/src/Roadkill.Tests.Integration/Api/Controllers/MartenAspIdentityLoadTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/src/Roadkill.Tests.Integration/Core/Repositories/DocumentStoreManager.cs
+++ b/src/Roadkill.Tests.Integration/Core/Repositories/DocumentStoreManager.cs
@@ -10,7 +10,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 {
 	public static class DocumentStoreManager
 	{
-		private static readonly ConcurrentDictionary<string, IDocumentStore> _documentStores = new ConcurrentDictionary<string, IDocumentStore>();
+		private static readonly ConcurrentDictionary<string, IDocumentStore> _documentStores = new();
 
 		public static string ConnectionString = "host=localhost;port=5432;database=postgres;username=roadkill;password=roadkill;";
 

--- a/src/Roadkill.Tests.Integration/Core/Repositories/DummyDataMakerTests.cs
+++ b/src/Roadkill.Tests.Integration/Core/Repositories/DummyDataMakerTests.cs
@@ -4,7 +4,6 @@ using AutoFixture;
 using Marten;
 using Roadkill.Core.Entities;
 using Roadkill.Core.Repositories;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Roadkill.Tests.Integration.Core.Repositories

--- a/src/Roadkill.Tests.Integration/Core/Repositories/PageRepositoryTests.cs
+++ b/src/Roadkill.Tests.Integration/Core/Repositories/PageRepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -45,7 +45,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void AddNewPage_should_add_page_and_increment_id()
+		public async Task AddNewPage_should_add_page_and_increment_id()
 		{
 			// given
 			string createdBy = "lyon";
@@ -75,7 +75,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void AllPages()
+		public async Task AllPages()
 		{
 			// given
 			PageRepository repository = CreateRepository();
@@ -85,15 +85,15 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 			IEnumerable<Page> actualPages = await repository.AllPagesAsync();
 
 			// then
-			actualPages.Count().ShouldBe(pages.Count());
+			actualPages.Count().ShouldBe(pages.Count);
 		}
 
 		[Fact]
-		public async void AllTags_should_return_raw_tags_for_all_pages()
+		public async Task AllTags_should_return_raw_tags_for_all_pages()
 		{
 			// given
 			PageRepository repository = CreateRepository();
-			List<Page> pages = _fixture.CreateMany<Page>(10).ToList();
+			var pages = _fixture.CreateMany<Page>(10).ToList();
 			pages.ForEach(p => p.Tags = "tag1, tag2, tag3");
 			CreateTenPages(repository, pages);
 
@@ -101,12 +101,12 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 			IEnumerable<string> actualTags = await repository.AllTagsAsync();
 
 			// then
-			actualTags.Count().ShouldBe(pages.Count());
+			actualTags.Count().ShouldBe(pages.Count);
 			actualTags.First().ShouldBe("tag1, tag2, tag3");
 		}
 
 		[Fact]
-		public async void DeletePage_should_delete_specific_page()
+		public async Task DeletePage_should_delete_specific_page()
 		{
 			// given
 			PageRepository repository = CreateRepository();
@@ -193,7 +193,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 			PageRepository repository = CreateRepository();
 			CreateTenPages(repository);
 
-			List<Page> pages = _fixture.CreateMany<Page>(3).ToList();
+			var pages = _fixture.CreateMany<Page>(3).ToList();
 			pages.ForEach(p => p.Tags = _fixture.Create<string>() + ", facebook-data-leak");
 			await repository.AddNewPageAsync(pages[0]);
 			await repository.AddNewPageAsync(pages[1]);
@@ -281,21 +281,19 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 
 		private void PrintPages()
 		{
-			using (var connection = new NpgsqlConnection(DocumentStoreManager.ConnectionString))
-			{
-				connection.Open();
-				var command = connection.CreateCommand();
-				command.CommandText = "delete from public.mt_doc_page";
-				command.CommandText = "delete from public.mt_doc_pagecontent";
+			using var connection = new NpgsqlConnection(DocumentStoreManager.ConnectionString);
+			connection.Open();
+			var command = connection.CreateCommand();
+			command.CommandText = "delete from public.mt_doc_page";
+			command.CommandText = "delete from public.mt_doc_pagecontent";
 
-				command.CommandText = "select count(*) from public.mt_doc_page";
-				long result = (long)command.ExecuteScalar();
-				_outputHelper.WriteLine("Pages: {0}", result);
+			command.CommandText = "select count(*) from public.mt_doc_page";
+			long result = (long)command.ExecuteScalar();
+			_outputHelper.WriteLine("Pages: {0}", result);
 
-				command.CommandText = "select count(*) from public.mt_doc_pagecontent";
-				result = (long)command.ExecuteScalar();
-				_outputHelper.WriteLine("PageContents: {0}", result);
-			}
+			command.CommandText = "select count(*) from public.mt_doc_pagecontent";
+			result = (long)command.ExecuteScalar();
+			_outputHelper.WriteLine("PageContents: {0}", result);
 		}
 	}
 }

--- a/src/Roadkill.Tests.Integration/Core/Repositories/PageVersionRepositoryTests.cs
+++ b/src/Roadkill.Tests.Integration/Core/Repositories/PageVersionRepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -42,7 +42,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void AddNewVersion()
+		public async Task AddNewVersion()
 		{
 			// given
 			PageVersionRepository repository = CreateRepository();
@@ -62,7 +62,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void AllVersions()
+		public async Task AllVersions()
 		{
 			// given
 			PageVersionRepository repository = CreateRepository();
@@ -77,7 +77,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void DeleteVersion()
+		public async Task DeleteVersion()
 		{
 			// given
 			PageVersionRepository repository = CreateRepository();
@@ -202,7 +202,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 			IDocumentStore documentStore = DocumentStoreManager.GetMartenDocumentStore(typeof(PageVersionRepository), _outputHelper);
 			var pageRepository = new PageRepository(documentStore);
 
-			List<Page> pages = _fixture.CreateMany<Page>(10).ToList();
+			var pages = _fixture.CreateMany<Page>(10).ToList();
 
 			var pageVersions = new List<PageVersion>();
 			foreach (Page page in pages)

--- a/src/Roadkill.Tests.Integration/Core/Repositories/TestData.cs
+++ b/src/Roadkill.Tests.Integration/Core/Repositories/TestData.cs
@@ -34,7 +34,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 
-		public static Dictionary<string, string> TestConfigValues = new Dictionary<string, string>
+		public static Dictionary<string, string> TestConfigValues = new()
 		{
 			{ "Postgres:ConnectionString", "host=localhost;port=5432;database=postgres;username=roadkill;password=roadkill;" },
 			{ "Smtp:Host", "smtp.gmail.com" },
@@ -154,15 +154,14 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 
 			try
 			{
-				var result = manager.CreateAsync(user, password).GetAwaiter().GetResult();
+				var result = await manager.CreateAsync(user, password);
 				if (!result.Succeeded)
 				{
 					string errors = string.Join("\n", result.Errors.ToList().Select(x => x.Description));
 					throw new Exception("Failed to create editor user - " + errors);
 				}
 
-				manager.AddClaimAsync(user, RoadkillClaims.EditorClaim).GetAwaiter()
-					.GetResult();
+				await manager.AddClaimAsync(user, RoadkillClaims.EditorClaim);
 
 				_outputHelper.WriteLine("Created editor user with role");
 			}

--- a/src/Roadkill.Tests.Integration/Core/Repositories/UserRefreshTokenRepositoryTests.cs
+++ b/src/Roadkill.Tests.Integration/Core/Repositories/UserRefreshTokenRepositoryTests.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Security.Claims;
 using System.Threading.Tasks;
-using AutoFixture;
 //using Baseline;
 using Marten;
 using Roadkill.Core.Entities.Authorization;

--- a/src/Roadkill.Tests.Integration/Core/Repositories/UserRepositoryTests.cs
+++ b/src/Roadkill.Tests.Integration/Core/Repositories/UserRepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AutoFixture;
@@ -39,7 +39,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void DeleteAllUsers_should_clear_every_user()
+		public async System.Threading.Tasks.Task DeleteAllUsers_should_clear_every_user()
 		{
 			// given
 			User adminUser = _fixture.Build<User>()
@@ -74,11 +74,11 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void DeleteUser_should_delete_single_user()
+		public async System.Threading.Tasks.Task DeleteUser_should_delete_single_user()
 		{
 			// given
 			UserRepository repository = CreateRepository();
-			List<User> remainingUsers = _fixture.CreateMany<User>().ToList();
+			var remainingUsers = _fixture.CreateMany<User>().ToList();
 			remainingUsers.ForEach(async u =>
 			{
 				await repository.SaveOrUpdateUserAsync(u);
@@ -104,10 +104,10 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void FindAllEditors_should_return_editors_only()
+		public async System.Threading.Tasks.Task FindAllEditors_should_return_editors_only()
 		{
 			// given
-			List<User> editorUsers = _fixture.Build<User>()
+			var editorUsers = _fixture.Build<User>()
 													.With(x => x.IsAdmin, false)
 													.With(x => x.IsEditor, true)
 													.CreateMany()
@@ -129,10 +129,10 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void FindAllAdmins_should_return_admins_only()
+		public async System.Threading.Tasks.Task FindAllAdmins_should_return_admins_only()
 		{
 			// given
-			List<User> adminUsers = _fixture.Build<User>()
+			var adminUsers = _fixture.Build<User>()
 											.With(x => x.IsAdmin, true)
 											.With(x => x.IsEditor, false)
 											.CreateMany()
@@ -149,11 +149,11 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 			IEnumerable<User> actualAdmins = await repository.FindAllAdminsAsync();
 
 			// then
-			actualAdmins.Count().ShouldBe(adminUsers.Count());
+			actualAdmins.Count().ShouldBe(adminUsers.Count);
 		}
 
 		[Fact]
-		public async void GetAdminById_should_return_admin_user()
+		public async System.Threading.Tasks.Task GetAdminById_should_return_admin_user()
 		{
 			// given
 			UserRepository repository = CreateRepository();
@@ -174,7 +174,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void GetUserByActivationKey_should_return_user()
+		public async System.Threading.Tasks.Task GetUserByActivationKey_should_return_user()
 		{
 			// given
 			UserRepository repository = CreateRepository();
@@ -190,7 +190,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void GetEditorById_should_return_editor_only()
+		public async System.Threading.Tasks.Task GetEditorById_should_return_editor_only()
 		{
 			// given
 			UserRepository repository = CreateRepository();
@@ -212,7 +212,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		[Theory]
 		[InlineData(true)]
 		[InlineData(false)]
-		public async void GetUserByEmail_should_return_user(bool isActivated)
+		public async System.Threading.Tasks.Task GetUserByEmail_should_return_user(bool isActivated)
 		{
 			// given
 			UserRepository repository = CreateRepository();
@@ -233,7 +233,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		[Theory]
 		[InlineData(true)]
 		[InlineData(false)]
-		public async void GetUserById_should_return_user(bool isActivated)
+		public async System.Threading.Tasks.Task GetUserById_should_return_user(bool isActivated)
 		{
 			// given
 			UserRepository repository = CreateRepository();
@@ -252,7 +252,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void GetUserByPasswordResetKey_should_return_user()
+		public async System.Threading.Tasks.Task GetUserByPasswordResetKey_should_return_user()
 		{
 			// given
 			UserRepository repository = CreateRepository();
@@ -269,7 +269,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void GetUserByUsername_should_return_user()
+		public async System.Threading.Tasks.Task GetUserByUsername_should_return_user()
 		{
 			// given
 			UserRepository repository = CreateRepository();
@@ -286,7 +286,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void GetUserByUsernameOrEmail_should_return_user()
+		public async System.Threading.Tasks.Task GetUserByUsernameOrEmail_should_return_user()
 		{
 			// given
 			UserRepository repository = CreateRepository();
@@ -303,7 +303,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void SaveOrUpdateUser_should_create_new_user()
+		public async System.Threading.Tasks.Task SaveOrUpdateUser_should_create_new_user()
 		{
 			// given
 			UserRepository repository = CreateRepository();
@@ -318,7 +318,7 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 		}
 
 		[Fact]
-		public async void SaveOrUpdateUser_should_update_user()
+		public async System.Threading.Tasks.Task SaveOrUpdateUser_should_update_user()
 		{
 			// given
 			UserRepository repository = CreateRepository();

--- a/src/Roadkill.Tests.Integration/Core/Search/Adapters/ElasticSearchAdapterTests.cs
+++ b/src/Roadkill.Tests.Integration/Core/Search/Adapters/ElasticSearchAdapterTests.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture;
 using Elastic.Clients.Elasticsearch;
-//using Elasticsearch.Net;
-//using Nest;
 using Roadkill.Core.Entities;
 using Roadkill.Core.Search.Adapters;
 using Shouldly;

--- a/src/Roadkill.Tests.Unit/Api/Authorization/JwtTokenServiceTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/Authorization/JwtTokenServiceTests.cs
@@ -126,7 +126,7 @@ namespace Roadkill.Tests.Unit.Api.Authorization
 		}
 
 		[Fact]
-		public async Task should_get_jwt_token()
+		public void should_get_jwt_token()
 		{
 			// given
 			string currentJwtToken = "jwt token";

--- a/src/Roadkill.Tests.Unit/Api/Authorization/RolesAuthorizationHandlerTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/Authorization/RolesAuthorizationHandlerTests.cs
@@ -3,7 +3,6 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using NSubstitute;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.Policies;
 using Roadkill.Api.Authorization.Roles;
 using Shouldly;
@@ -81,13 +80,13 @@ namespace Roadkill.Tests.Unit.Api.Authorization
 			return new RoadkillPolicyRequirement(policyName);
 		}
 
-		private ClaimsPrincipal CreateClaimsPrincipal(string roleName)
+		private static ClaimsPrincipal CreateClaimsPrincipal(string roleName)
 		{
 			var claims = new List<Claim>()
 			{
-				new Claim(ClaimTypes.Role, roleName)
+				new(ClaimTypes.Role, roleName)
 			};
-			var claimsIdentities = new List<ClaimsIdentity> {new ClaimsIdentity(claims)};
+			var claimsIdentities = new List<ClaimsIdentity> {new(claims)};
 			return new ClaimsPrincipal(claimsIdentities);
 		}
 	}

--- a/src/Roadkill.Tests.Unit/Api/Controllers/AuthorizationControllerTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/Controllers/AuthorizationControllerTests.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.JWT;
 using Roadkill.Api.Common.Request;
 using Roadkill.Api.Common.Response;
@@ -106,7 +105,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 			_signinManagerMock.PasswordSignInAsync(roadkillUser, password, true, false)
 				.Returns(Task.FromResult(SignInResult.Success));
 
-			var claims = new List<Claim>() { new Claim("any", "thing") } as IList<Claim>;
+			var claims = new List<Claim>() { new("any", "thing") } as IList<Claim>;
 			
 			_userManagerMock.GetClaimsAsync(roadkillUser)
 				.Returns(Task.FromResult(claims));

--- a/src/Roadkill.Tests.Unit/Api/Controllers/ExportControllerTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/Controllers/ExportControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -32,12 +32,12 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 		public async Task ExportToXml()
 		{
 			// given
-			List<Page> actualPages = _fixture.CreateMany<Page>().ToList();
+			var actualPages = _fixture.CreateMany<Page>().ToList();
 
 			_pageRepositoryMock.AllPagesAsync()
 				.Returns(actualPages);
 
-			XmlSerializer serializer = new XmlSerializer(typeof(List<Page>));
+			var serializer = new XmlSerializer(typeof(List<Page>));
 
 			// when
 			ActionResult<string> actionResult = await _exportController.ExportPagesToXml();
@@ -47,7 +47,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 
 			string actualXml = actionResult.GetOkObjectResultValue();
 			var deserializedPages = serializer.Deserialize(new StringReader(actualXml)) as List<Page>;
-			deserializedPages.Count.ShouldBe(actualPages.Count());
+			deserializedPages.Count.ShouldBe(actualPages.Count);
 		}
 	}
 }

--- a/src/Roadkill.Tests.Unit/Api/Controllers/MarkdownControllerTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/Controllers/MarkdownControllerTests.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
-using AutoFixture;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.Policies;
 using Roadkill.Api.Controllers;
 using Roadkill.Text.Models;

--- a/src/Roadkill.Tests.Unit/Api/Controllers/PageVersionsControllerTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/Controllers/PageVersionsControllerTests.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using AutoFixture;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.Policies;
 using Roadkill.Api.Common.Request;
 using Roadkill.Api.Common.Response;
@@ -151,7 +148,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 		public async Task AllVersions()
 		{
 			// given
-			List<PageVersion> pageVersions = _fixture.CreateMany<PageVersion>().ToList();
+			var pageVersions = _fixture.CreateMany<PageVersion>().ToList();
 
 			_pageVersionRepositoryMock
 				.AllVersionsAsync()
@@ -172,7 +169,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 		public async Task FindPageVersionsByPageId()
 		{
 			// given
-			List<PageVersion> pageVersions = _fixture.CreateMany<PageVersion>().ToList();
+			var pageVersions = _fixture.CreateMany<PageVersion>().ToList();
 			int pageId = 42;
 			pageVersions.ForEach(p => p.PageId = pageId);
 
@@ -195,7 +192,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 		public async Task FindPageVersionsByAuthor()
 		{
 			// given
-			List<PageVersion> pageVersions = _fixture.CreateMany<PageVersion>().ToList();
+			var pageVersions = _fixture.CreateMany<PageVersion>().ToList();
 			string author = "weirdo";
 			pageVersions.ForEach(p => p.Author = author);
 
@@ -252,7 +249,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 		public async Task Delete()
 		{
 			// given
-			Guid pageVersionId = Guid.NewGuid();
+			var pageVersionId = Guid.NewGuid();
 
 			_pageVersionRepositoryMock
 				.DeleteVersionAsync(pageVersionId)

--- a/src/Roadkill.Tests.Unit/Api/Controllers/PagesControllerTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/Controllers/PagesControllerTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using AutoFixture;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.Policies;
 using Roadkill.Api.Common.Request;
 using Roadkill.Api.Common.Response;
@@ -166,7 +165,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 		public async Task FindHomePage_should_return_first_page_with_homepage_tag()
 		{
 			// given
-			List<Page> pages = _fixture.CreateMany<Page>(10).ToList();
+			var pages = _fixture.CreateMany<Page>(10).ToList();
 			for (int i = 0; i < pages.Count; i++)
 			{
 				pages[i].Tags += ", homepage";

--- a/src/Roadkill.Tests.Unit/Api/Controllers/TagsControllerTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/Controllers/TagsControllerTests.cs
@@ -1,12 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
-using Roadkill.Api.Authorization;
 using Roadkill.Api.Authorization.Policies;
 using Roadkill.Api.Common.Response;
 using Roadkill.Api.Controllers;
@@ -75,7 +73,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 		public async Task AllTags_should_return_all_tags_and_fill_count_property()
 		{
 			// given
-			List<string> tags = _fixture.CreateMany<string>().ToList();
+			var tags = _fixture.CreateMany<string>().ToList();
 
 			var duplicateTags = new List<string>();
 			duplicateTags.Add("duplicate-tag");
@@ -109,7 +107,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 			string tagToSearch = "typo-tag";
 			string newTag = "fixed-tag";
 
-			List<Page> pagesWithTags = _fixture.CreateMany<Page>().ToList();
+			var pagesWithTags = _fixture.CreateMany<Page>().ToList();
 			pagesWithTags.ForEach(p => { p.Tags = existingTags; });
 
 			_pageRepositoryMock
@@ -134,7 +132,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 			// given
 			string tag = "gutentag";
 
-			List<Page> pagesWithTag = _fixture.CreateMany<Page>().ToList();
+			var pagesWithTag = _fixture.CreateMany<Page>().ToList();
 			pagesWithTag[0].Tags += $", {tag}";
 			pagesWithTag[1].Tags += $", {tag}";
 			pagesWithTag[2].Tags += $", {tag}";
@@ -151,7 +149,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 			IEnumerable<PageResponse> response = actionResult.GetOkObjectResultValue();
 
 			response.Count()
-					.ShouldBe(pagesWithTag.Count());
+					.ShouldBe(pagesWithTag.Count);
 		}
 	}
 }

--- a/src/Roadkill.Tests.Unit/Api/ObjectConverters/PageObjectsConverterTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/ObjectConverters/PageObjectsConverterTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Reflection;
 using AutoFixture;
 using AutoMapper;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,7 +6,6 @@ using Roadkill.Api.Common.Response;
 using Roadkill.Api.Extensions;
 using Roadkill.Api.ObjectConverters;
 using Roadkill.Core.Entities;
-using Shouldly;
 using Xunit;
 
 namespace Roadkill.Tests.Unit.Api.ObjectConverters

--- a/src/Roadkill.Tests.Unit/Api/ObjectConverters/PageVersionObjectsConverterTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/ObjectConverters/PageVersionObjectsConverterTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Reflection;
 using AutoFixture;
 using AutoMapper;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,7 +6,6 @@ using Roadkill.Api.Common.Response;
 using Roadkill.Api.Extensions;
 using Roadkill.Api.ObjectConverters;
 using Roadkill.Core.Entities;
-using Shouldly;
 using Xunit;
 
 namespace Roadkill.Tests.Unit.Api.ObjectConverters

--- a/src/Roadkill.Tests.Unit/Api/ObjectConverters/UserObjectsConverterTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/ObjectConverters/UserObjectsConverterTests.cs
@@ -1,15 +1,10 @@
-using System;
-using System.Reflection;
 using AutoFixture;
 using AutoMapper;
 using Microsoft.Extensions.DependencyInjection;
-using Roadkill.Api.Common.Request;
 using Roadkill.Api.Common.Response;
 using Roadkill.Api.Extensions;
 using Roadkill.Api.ObjectConverters;
-using Roadkill.Core.Entities;
 using Roadkill.Core.Entities.Authorization;
-using Shouldly;
 using Xunit;
 
 namespace Roadkill.Tests.Unit.Api.ObjectConverters

--- a/src/Roadkill.Tests.Unit/AssertExtensions.cs
+++ b/src/Roadkill.Tests.Unit/AssertExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Xunit;
@@ -29,7 +29,7 @@ namespace Roadkill.Tests.Unit
 				}
 			});
 
-			Assert.False(true, "Could not find item in the collection");
+			Assert.Fail("Could not find item in the collection");
 		}
 	}
 }

--- a/src/Roadkill.Tests.Unit/Core/Search/Parsers/SearchQueryParserTests.cs
+++ b/src/Roadkill.Tests.Unit/Core/Search/Parsers/SearchQueryParserTests.cs
@@ -79,7 +79,7 @@ namespace Roadkill.Tests.Unit.Core.Search.Parsers
 			queryResult.Fields.Count().ShouldBe(2);
 		}
 
-		private SearchQueryParser CreateParser()
+		private static SearchQueryParser CreateParser()
 		{
 			return new SearchQueryParser();
 		}

--- a/src/Roadkill.Tests.Unit/ShouldlyAttributeExtensions.cs
+++ b/src/Roadkill.Tests.Unit/ShouldlyAttributeExtensions.cs
@@ -3,8 +3,6 @@ using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
-using Roadkill.Api.Authorization;
-using Serilog.Parsing;
 using Shouldly;
 using Xunit;
 
@@ -76,7 +74,7 @@ namespace Roadkill.Tests.Unit
 			var customAttributes = methodType.GetCustomAttributes(attributeType, false);
 			customAttributes.Length.ShouldBeGreaterThan(0, $"No {attributeType.Name} found for {methodName}");
 
-			RouteAttribute routeAttribute = customAttributes[0] as RouteAttribute;
+			var routeAttribute = customAttributes[0] as RouteAttribute;
 			routeAttribute.Template.ShouldBe(routeTemplate);
 		}
 
@@ -103,7 +101,7 @@ namespace Roadkill.Tests.Unit
 			var customAttributes = methodType.GetCustomAttributes(attributeType, false);
 			customAttributes.Length.ShouldBeGreaterThan(0, $"No {attributeType.Name} found for {methodName}");
 
-			AuthorizeAttribute authorizeAttribute = customAttributes[0] as AuthorizeAttribute;
+			var authorizeAttribute = customAttributes[0] as AuthorizeAttribute;
 
 			authorizeAttribute.ShouldNotBeNull($"No AuthorizeAttribute policy string specified for {methodName}");
 			authorizeAttribute?.Policy.ShouldNotBeNullOrEmpty($"No AuthorizeAttribute policy string specified for {methodName}");

--- a/src/Roadkill.Tests.Unit/Text/CustomTokens/CustomTokenParserTests.cs
+++ b/src/Roadkill.Tests.Unit/Text/CustomTokens/CustomTokenParserTests.cs
@@ -26,9 +26,9 @@ namespace Roadkill.Tests.Unit.Text.CustomTokens
 		public void should_contain_empty_list_when_tokens_file_not_found()
 		{
 			// Arrange
-			TextSettings settings = new TextSettings();
+			var settings = new TextSettings();
 			settings.CustomTokensPath = Path.Combine(Directory.GetCurrentDirectory(), "Unit", "Text", "CustomTokens", "doesntexist.xml");
-			CustomTokenParser parser = new CustomTokenParser(settings, _logger);
+			var parser = new CustomTokenParser(settings, _logger);
 
 			string expectedHtml = "@@warningbox:ENTER YOUR CONTENT HERE {{some link}}@@";
 
@@ -43,12 +43,12 @@ namespace Roadkill.Tests.Unit.Text.CustomTokens
 		public void should_contain_empty_list_when_when_deserializing_bad_xml_file()
 		{
 			// Arrange
-			TextSettings settings = new TextSettings();
+			var settings = new TextSettings();
 			settings.CustomTokensPath = Path.Combine(Directory.GetCurrentDirectory(), "Text", "CustomTokens", "badxml-file.json");
 			string expectedHtml = "@@warningbox:ENTER YOUR CONTENT HERE {{some link}}@@";
 
 			// Act
-			CustomTokenParser parser = new CustomTokenParser(settings, _logger);
+			var parser = new CustomTokenParser(settings, _logger);
 			string actualHtml = parser.ReplaceTokensAfterParse("@@warningbox:ENTER YOUR CONTENT HERE {{some link}}@@");
 
 			// Assert
@@ -59,9 +59,9 @@ namespace Roadkill.Tests.Unit.Text.CustomTokens
 		public void warningbox_token_should_return_html_fragment()
 		{
 			// Arrange
-			TextSettings settings = new TextSettings();
+			var settings = new TextSettings();
 			settings.CustomTokensPath = Path.Combine(Directory.GetCurrentDirectory(), "Text", "CustomTokens", "customvariables.xml");
-			CustomTokenParser parser = new CustomTokenParser(settings, _logger);
+			var parser = new CustomTokenParser(settings, _logger);
 
 			string expectedHtml = @"<div class=""alert alert-warning"">ENTER YOUR CONTENT HERE {{some link}}</div><br style=""clear:both""/>";
 

--- a/src/Roadkill.Tests.Unit/Text/Parsers/Images/ImageSrcParserTests.cs
+++ b/src/Roadkill.Tests.Unit/Text/Parsers/Images/ImageSrcParserTests.cs
@@ -30,7 +30,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Images
 		public void should_ignore_urls_starting_with_ww_http_and_https(string imageUrl)
 		{
 			// Arrange
-			HtmlImageTag htmlImageTag = new HtmlImageTag(imageUrl, imageUrl, "alt", "title");
+			var htmlImageTag = new HtmlImageTag(imageUrl, imageUrl, "alt", "title");
 
 			// Act
 			HtmlImageTag actualTag = _srcParser.Parse(htmlImageTag);
@@ -49,7 +49,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Images
 				.Returns(callInfo => callInfo.Arg<string>());
 
 			_textSettings.AttachmentsUrlPath = "/attuchments/";
-			HtmlImageTag htmlImageTag = new HtmlImageTag(path, path, "alt", "title");
+			var htmlImageTag = new HtmlImageTag(path, path, "alt", "title");
 
 			// Act
 			HtmlImageTag actualTag = _srcParser.Parse(htmlImageTag);

--- a/src/Roadkill.Tests.Unit/Text/Parsers/Links/LinkHrefParserTests.cs
+++ b/src/Roadkill.Tests.Unit/Text/Parsers/Links/LinkHrefParserTests.cs
@@ -35,7 +35,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void href_with_dashes_and_23_are_not_encoded()
 		{
 			// Arrange
-			HtmlLinkTag linkTag = new HtmlLinkTag("https://www.google.com/some-page-23", "https://www.google.com/some-page-23", "text", "");
+			var linkTag = new HtmlLinkTag("https://www.google.com/some-page-23", "https://www.google.com/some-page-23", "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -48,7 +48,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void href_links_with_the_word_script_in_url_should_not_be_cleaned()
 		{
 			// Arrange - Issue #159 (Bitbucket) (deSCRIPTion)
-			HtmlLinkTag linkTag = new HtmlLinkTag("http://msdn.microsoft.com/en-us/library/system.componentmodel.descriptionattribute.aspx", "http://msdn.microsoft.com/en-us/library/system.componentmodel.descriptionattribute.aspx", "Component description", "");
+			var linkTag = new HtmlLinkTag("http://msdn.microsoft.com/en-us/library/system.componentmodel.descriptionattribute.aspx", "http://msdn.microsoft.com/en-us/library/system.componentmodel.descriptionattribute.aspx", "Component description", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -67,7 +67,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void should_add_external_links_css_class_to_links_and_keep_url(string url)
 		{
 			// Arrange
-			HtmlLinkTag linkTag = new HtmlLinkTag(url, url, "text", "");
+			var linkTag = new HtmlLinkTag(url, url, "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -81,7 +81,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void should_not_add_external_link_cssclass_for_anchor_tags()
 		{
 			// Arrange
-			HtmlLinkTag linkTag = new HtmlLinkTag("#my-anchor", "#my-anchor", "text", "");
+			var linkTag = new HtmlLinkTag("#my-anchor", "#my-anchor", "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -98,7 +98,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		{
 			// Arrange
 			string actualPath = $"{prefix}my/folder/image1.jpg";
-			HtmlLinkTag linkTag = new HtmlLinkTag(actualPath, actualPath, "text", "");
+			var linkTag = new HtmlLinkTag(actualPath, actualPath, "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -111,7 +111,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void should_use_url_helper_for_special_pages()
 		{
 			// Arrange
-			HtmlLinkTag linkTag = new HtmlLinkTag("Special:blah", "Special:blah", "text", "");
+			var linkTag = new HtmlLinkTag("Special:blah", "Special:blah", "text", "");
 			_urlHelperMock
 				.Content(Arg.Any<string>())
 				.Returns("~/wiki/Special:blah/url-helper");
@@ -127,7 +127,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void links_starting_with_special_should_resolve_as_full_specialpage()
 		{
 			// Arrange
-			HtmlLinkTag linkTag = new HtmlLinkTag("Special:Foo", "Special:Foo", "text", "");
+			var linkTag = new HtmlLinkTag("Special:Foo", "Special:Foo", "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -140,7 +140,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void href_external_link_with_anchor_should_retain_anchor()
 		{
 			// Arrange - Issue #172 (Bitbucket)
-			HtmlLinkTag linkTag = new HtmlLinkTag("http://www.google.com/?blah=xyz#myanchor", "http://www.google.com/?blah=xyz#myanchor", "text", "");
+			var linkTag = new HtmlLinkTag("http://www.google.com/?blah=xyz#myanchor", "http://www.google.com/?blah=xyz#myanchor", "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -154,7 +154,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		{
 			// Arrange
 			string pageTitle = "foo page";
-			Page dummyPage = new Page() { Id = 1, Title = pageTitle };
+			var dummyPage = new Page() { Id = 1, Title = pageTitle };
 			dynamic urlValues = new { id = dummyPage.Id, title = "foo-page" };
 
 			_urlHelperMock
@@ -165,7 +165,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 				.GetPageByTitleAsync(pageTitle)
 				.Returns(dummyPage);
 
-			HtmlLinkTag linkTag = new HtmlLinkTag("foo-page?blah=xyz#myanchor", "foo-page?blah=xyz#myanchor", "text", "");
+			var linkTag = new HtmlLinkTag("foo-page?blah=xyz#myanchor", "foo-page?blah=xyz#myanchor", "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -178,7 +178,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void href_external_link_with_urlencoded_anchor_should_retain_anchor()
 		{
 			// Arrange - Issue #172 (Bitbucket)
-			HtmlLinkTag linkTag = new HtmlLinkTag("http://www.google.com/?blah=xyz%23myanchor", "http://www.google.com/?blah=xyz%23myanchor", "text", "");
+			var linkTag = new HtmlLinkTag("http://www.google.com/?blah=xyz%23myanchor", "http://www.google.com/?blah=xyz%23myanchor", "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -197,12 +197,12 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 				.Returns(expectedHref);
 
 			string pageTitle = "foo";
-			Page dummyPage = new Page() { Id = 1, Title = pageTitle };
+			var dummyPage = new Page() { Id = 1, Title = pageTitle };
 			_pageRepository
 				.GetPageByTitleAsync(pageTitle)
 				.Returns(dummyPage);
 
-			HtmlLinkTag linkTag = new HtmlLinkTag("foo#myanchor", "foo#myanchor", "text", "");
+			var linkTag = new HtmlLinkTag("foo#myanchor", "foo#myanchor", "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -221,11 +221,11 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 				.Returns(expectedHref);
 
 			string pageTitle = "foo";
-			Page dummyPage = new Page() { Id = 1, Title = pageTitle };
+			var dummyPage = new Page() { Id = 1, Title = pageTitle };
 			_pageRepository
 				.GetPageByTitleAsync(pageTitle)
 				.Returns(dummyPage);
-			HtmlLinkTag linkTag = new HtmlLinkTag("my-page-on-engineering", "my-page-on-engineering", "text", "");
+			var linkTag = new HtmlLinkTag("my-page-on-engineering", "my-page-on-engineering", "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -245,12 +245,12 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 				.Returns(expectedHref);
 
 			string pageTitle = "foo";
-			Page dummyPage = new Page() { Id = 1, Title = pageTitle };
+			var dummyPage = new Page() { Id = 1, Title = pageTitle };
 			_pageRepository
 				.GetPageByTitleAsync(pageTitle)
 				.Returns(dummyPage);
 
-			HtmlLinkTag linkTag = new HtmlLinkTag("football", "foo-page", "text", "");
+			var linkTag = new HtmlLinkTag("football", "foo-page", "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -263,7 +263,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void should_add_missing_page_link_css_class_when_internal_link_does_not_exist()
 		{
 			// Arrange
-			HtmlLinkTag linkTag = new HtmlLinkTag("doesnt-exist", "doesnt-exist", "text", "");
+			var linkTag = new HtmlLinkTag("doesnt-exist", "doesnt-exist", "text", "");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);
@@ -282,12 +282,12 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 				.Returns(expectedHref);
 
 			string pageTitle = "foo";
-			Page dummyPage = new Page() { Id = 1, Title = pageTitle };
+			var dummyPage = new Page() { Id = 1, Title = pageTitle };
 			_pageRepository
 				.GetPageByTitleAsync(pageTitle)
 				.Returns(dummyPage);
 
-			HtmlLinkTag linkTag = new HtmlLinkTag("despair", "", "text", "new");
+			var linkTag = new HtmlLinkTag("despair", "", "text", "new");
 
 			// Act
 			HtmlLinkTag actualTag = _linkHrefParser.Parse(linkTag);

--- a/src/Roadkill.Tests.Unit/Text/Parsers/Links/MarkupLinkUpdaterTests.cs
+++ b/src/Roadkill.Tests.Unit/Text/Parsers/Links/MarkupLinkUpdaterTests.cs
@@ -11,8 +11,8 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void containspagelink_should_return_true_when_title_exists_in_markdown()
 		{
 			// Arrange
-			MarkdigParser parser = new MarkdigParser();
-			MarkupLinkUpdater updater = new MarkupLinkUpdater(parser);
+			var parser = new MarkdigParser();
+			var updater = new MarkupLinkUpdater(parser);
 
 			string text = "here is a nice [the link text](the-internal-wiki-page-title)";
 
@@ -27,8 +27,8 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void containspagelink_should_return_false_when_title_has_no_dashes_in_markdown()
 		{
 			// Arrange
-			MarkdigParser parser = new MarkdigParser();
-			MarkupLinkUpdater updater = new MarkupLinkUpdater(parser);
+			var parser = new MarkdigParser();
+			var updater = new MarkupLinkUpdater(parser);
 
 			string text = "here is a nice [the link text](Markdown enforces dashes for spaces in urls)";
 
@@ -44,7 +44,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		{
 			// Arrange
 			var parser = new MarkdigParser();
-			MarkupLinkUpdater updater = new MarkupLinkUpdater(parser);
+			var updater = new MarkupLinkUpdater(parser);
 
 			string text = "here is a nice [[the internal wiki page title|the link text]]";
 
@@ -59,8 +59,8 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void containspagelink_should_return_false_when_title_does_not_exist_in_markdown()
 		{
 			// Arrange
-			MarkdigParser parser = new MarkdigParser();
-			MarkupLinkUpdater updater = new MarkupLinkUpdater(parser);
+			var parser = new MarkdigParser();
+			var updater = new MarkupLinkUpdater(parser);
 
 			string text = "here is a nice [the link text](the-internal-wiki-page-title)";
 
@@ -76,7 +76,7 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		{
 			// Arrange
 			var parser = new MarkdigParser();
-			MarkupLinkUpdater updater = new MarkupLinkUpdater(parser);
+			var updater = new MarkupLinkUpdater(parser);
 
 			string text = @"//here is a nice **[the link text](the-internal-wiki-page-title)** and//
                             another one: *here is a nice [the link text](the-internal-wiki-page-title) and
@@ -105,8 +105,8 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void replacepagelinks_should_rename_basic_markdown_title()
 		{
 			// Arrange
-			MarkdigParser parser = new MarkdigParser();
-			MarkupLinkUpdater updater = new MarkupLinkUpdater(parser);
+			var parser = new MarkdigParser();
+			var updater = new MarkupLinkUpdater(parser);
 
 			string text = "here is a nice [the link text](the-internal-wiki-page-title)";
 			string expectedMarkup = "here is a nice [the link text](buy-stuff-online)";
@@ -122,8 +122,8 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void replacepagelinks_should_rename_multiple_markdown_titles()
 		{
 			// Arrange
-			MarkdigParser parser = new MarkdigParser();
-			MarkupLinkUpdater updater = new MarkupLinkUpdater(parser);
+			var parser = new MarkdigParser();
+			var updater = new MarkupLinkUpdater(parser);
 
 			string text = @"here is a nice [the link text](the-internal-wiki-page-title) and
                             another one: here is a nice [the link text](the-internal-wiki-page-title) and
@@ -144,8 +144,8 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void replacepagelinks_should_rename_title_inside_markdown_block()
 		{
 			// Arrange
-			MarkdigParser parser = new MarkdigParser();
-			MarkupLinkUpdater updater = new MarkupLinkUpdater(parser);
+			var parser = new MarkdigParser();
+			var updater = new MarkupLinkUpdater(parser);
 
 			string text = @"here is a nice [the link text](the-internal-wiki-page-title) and
                             another one: here is a nice [the link text](the-internal-wiki-page-title) and
@@ -166,8 +166,8 @@ namespace Roadkill.Tests.Unit.Text.Parsers.Links
 		public void replacepagelinks_should_not_rename_title_that_is_not_found_in_markdown()
 		{
 			// Arrange
-			MarkdigParser parser = new MarkdigParser();
-			MarkupLinkUpdater updater = new MarkupLinkUpdater(parser);
+			var parser = new MarkdigParser();
+			var updater = new MarkupLinkUpdater(parser);
 
 			string text = @"*here* is a nice **[the link text](the-internal-wiki-page-title)** and
                             another one: *here is a nice [the link text](the-internal-wiki-page-title) and

--- a/src/Roadkill.Tests.Unit/Text/Parsers/Markdig/MarkdigImageAndLinkWalkerTests.cs
+++ b/src/Roadkill.Tests.Unit/Text/Parsers/Markdig/MarkdigImageAndLinkWalkerTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using Markdig;

--- a/src/Roadkill.Tests.Unit/Text/Sanitizer/HtmlSanitizerFactoryTests.cs
+++ b/src/Roadkill.Tests.Unit/Text/Sanitizer/HtmlSanitizerFactoryTests.cs
@@ -71,7 +71,7 @@ namespace Roadkill.Tests.Unit.Text.Sanitizer
 			expectedHtml.ShouldBe(actualHtml);
 		}
 
-		private HtmlSanitizerFactory CreateFactory(TextSettings textSettings = null, IHtmlWhiteListProvider whiteListProviderMock = null)
+		private static HtmlSanitizerFactory CreateFactory(TextSettings textSettings = null, IHtmlWhiteListProvider whiteListProviderMock = null)
 		{
 			if (textSettings == null)
 			{

--- a/src/Roadkill.Tests.Unit/Text/Sanitizer/HtmlWhiteListProviderTests.cs
+++ b/src/Roadkill.Tests.Unit/Text/Sanitizer/HtmlWhiteListProviderTests.cs
@@ -45,7 +45,7 @@ namespace Roadkill.Tests.Unit.Text.Sanitizer
 		public void should_return_default_whitelistsettings_when_path_is_empty()
 		{
 			// given
-			var defaultSettings = _htmlWhiteListProvider.CreateDefaultWhiteList();
+			var defaultSettings = HtmlWhiteListProvider.CreateDefaultWhiteList();
 
 			// when
 			HtmlWhiteListSettings settings = _htmlWhiteListProvider.Deserialize();
@@ -59,7 +59,7 @@ namespace Roadkill.Tests.Unit.Text.Sanitizer
 		{
 			// given
 			_textSettings.HtmlElementWhiteListPath = "file that doesnt exist.json";
-			var defaultSettings = _htmlWhiteListProvider.CreateDefaultWhiteList();
+			var defaultSettings = HtmlWhiteListProvider.CreateDefaultWhiteList();
 
 			// when
 			HtmlWhiteListSettings settings = _htmlWhiteListProvider.Deserialize();
@@ -73,7 +73,7 @@ namespace Roadkill.Tests.Unit.Text.Sanitizer
 		{
 			// given
 			_textSettings.HtmlElementWhiteListPath = Path.Combine(Directory.GetCurrentDirectory(), "Text", "Sanitizer", "dodgy-whitelist.json");
-			var defaultSettings = _htmlWhiteListProvider.CreateDefaultWhiteList();
+			var defaultSettings = HtmlWhiteListProvider.CreateDefaultWhiteList();
 
 			// when
 			HtmlWhiteListSettings settings = _htmlWhiteListProvider.Deserialize();

--- a/src/Roadkill.Text/CustomTokens/CustomTokenParser.cs
+++ b/src/Roadkill.Text/CustomTokens/CustomTokenParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -88,19 +88,17 @@ namespace Roadkill.Text.CustomTokens
 
 			try
 			{
-				using (FileStream stream = new FileStream(settings.CustomTokensPath, FileMode.Open, FileAccess.Read))
-				{
-					XmlSerializer serializer = new XmlSerializer(typeof(List<TextToken>));
-					IEnumerable<TextToken> textTokens = (List<TextToken>)serializer.Deserialize(stream);
+				using var stream = new FileStream(settings.CustomTokensPath, FileMode.Open, FileAccess.Read);
+				var serializer = new XmlSerializer(typeof(List<TextToken>));
+				IEnumerable<TextToken> textTokens = (List<TextToken>)serializer.Deserialize(stream);
 
-					if (textTokens == null)
-					{
-						return new List<TextToken>();
-					}
-					else
-					{
-						return textTokens;
-					}
+				if (textTokens == null)
+				{
+					return new List<TextToken>();
+				}
+				else
+				{
+					return textTokens;
 				}
 			}
 			catch (IOException e)

--- a/src/Roadkill.Text/Parsers/Images/ImageSrcParser.cs
+++ b/src/Roadkill.Text/Parsers/Images/ImageSrcParser.cs
@@ -6,7 +6,7 @@ namespace Roadkill.Text.Parsers.Images
 {
 	public class ImageSrcParser
 	{
-		private static readonly Regex _imgFileRegex = new Regex("^File:", RegexOptions.IgnoreCase);
+		private static readonly Regex _imgFileRegex = new("^File:", RegexOptions.IgnoreCase);
 
 		private readonly TextSettings _textSettings;
 

--- a/src/Roadkill.Text/Parsers/Links/Converters/AttachmentLinkConverter.cs
+++ b/src/Roadkill.Text/Parsers/Links/Converters/AttachmentLinkConverter.cs
@@ -33,18 +33,23 @@ namespace Roadkill.Text.Parsers.Links.Converters
 
 		public HtmlLinkTag Convert(HtmlLinkTag htmlLinkTag)
 		{
+			if (htmlLinkTag == null)
+			{
+				return null;
+			}
+
 			string href = htmlLinkTag.OriginalHref;
 			string upperHref = href?.ToUpperInvariant() ?? "";
 
 			if (!upperHref.StartsWith("ATTACHMENT:", StringComparison.Ordinal) &&
-				!upperHref.StartsWith("~", StringComparison.Ordinal))
+			    !upperHref.StartsWith("~", StringComparison.Ordinal))
 			{
 				return htmlLinkTag;
 			}
 
 			if (upperHref.StartsWith("ATTACHMENT:", StringComparison.Ordinal))
 			{
-				href = href.Remove(0, 11);
+				href = href!.Remove(0, 11);
 				if (!href.StartsWith("/", StringComparison.Ordinal))
 				{
 					href = "/" + href;
@@ -53,7 +58,7 @@ namespace Roadkill.Text.Parsers.Links.Converters
 			else if (upperHref.StartsWith("~/", StringComparison.Ordinal))
 			{
 				// Remove the ~
-				href = href.Remove(0, 1);
+				href = href!.Remove(0, 1);
 			}
 
 			// Get the full path to the attachment

--- a/src/Roadkill.Text/Parsers/Links/Converters/SpecialLinkConverter.cs
+++ b/src/Roadkill.Text/Parsers/Links/Converters/SpecialLinkConverter.cs
@@ -27,8 +27,13 @@ namespace Roadkill.Text.Parsers.Links.Converters
 
 		public HtmlLinkTag Convert(HtmlLinkTag htmlLinkTag)
 		{
+			if (htmlLinkTag == null)
+			{
+				return null;
+			}
+
 			string href = htmlLinkTag.OriginalHref;
-			string upperHref = href?.ToUpperInvariant();
+			string upperHref = href?.ToUpperInvariant() ?? ""; 
 
 			if (!upperHref.StartsWith("SPECIAL:", StringComparison.Ordinal))
 			{

--- a/src/Roadkill.Text/Parsers/Links/HtmlLinkTag.cs
+++ b/src/Roadkill.Text/Parsers/Links/HtmlLinkTag.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -9,7 +9,7 @@ namespace Roadkill.Text.Parsers.Links
 	/// </summary>
 	public class HtmlLinkTag
 	{
-		private readonly List<string> _externalLinkPrefixes = new List<string>()
+		private readonly List<string> _externalLinkPrefixes = new()
 		{
 			"http://",
 			"https://",

--- a/src/Roadkill.Text/Parsers/Links/LinkHrefParser.cs
+++ b/src/Roadkill.Text/Parsers/Links/LinkHrefParser.cs
@@ -18,9 +18,9 @@ namespace Roadkill.Text.Parsers.Links
 	/// </summary>
 	public class LinkHrefParser
 	{
-		private static readonly Regex _querystringRegex = new Regex("(?<querystring>(\\?).+)", RegexOptions.IgnoreCase);
+		private static readonly Regex _querystringRegex = new("(?<querystring>(\\?).+)", RegexOptions.IgnoreCase);
 
-		private static readonly Regex _anchorRegex = new Regex("(?<hash>(#|%23).+)", RegexOptions.IgnoreCase);
+		private static readonly Regex _anchorRegex = new("(?<hash>(#|%23).+)", RegexOptions.IgnoreCase);
 
 		private readonly IPageRepository _pageRepository;
 
@@ -29,7 +29,7 @@ namespace Roadkill.Text.Parsers.Links
 		// TODO: NETStandard - replace urlhelper to IUrlHelper
 		private readonly IUrlHelper _urlHelper;
 
-		private readonly List<string> _externalLinkPrefixes = new List<string>()
+		private readonly List<string> _externalLinkPrefixes = new()
 		{
 			"http://",
 			"https://",
@@ -191,7 +191,7 @@ namespace Roadkill.Text.Parsers.Links
 			if (page != null)
 			{
 				string encodedTitle = EncodePageTitle(page.Title);
-				UrlActionContext actionContext = new UrlActionContext()
+				var actionContext = new UrlActionContext()
 				{
 					Action = "Index",
 					Controller = "Wiki",
@@ -204,7 +204,7 @@ namespace Roadkill.Text.Parsers.Links
 			else
 			{
 				// e.g. /pages/new?title=xyz
-				UrlActionContext actionContext = new UrlActionContext()
+				var actionContext = new UrlActionContext()
 				{
 					Action = "New",
 					Controller = "Pages",

--- a/src/Roadkill.Text/Parsers/Links/MarkupLinkUpdater.cs
+++ b/src/Roadkill.Text/Parsers/Links/MarkupLinkUpdater.cs
@@ -31,7 +31,7 @@ namespace Roadkill.Text.Parsers.Links
 			pageName = AddDashesForMarkdownTitle(pageName);
 			string customRegex = GetRegexForTitle(pageName);
 
-			Regex regex = new Regex(customRegex, RegexOptions.IgnoreCase);
+			var regex = new Regex(customRegex, RegexOptions.IgnoreCase);
 			return regex.IsMatch(text);
 		}
 
@@ -48,7 +48,7 @@ namespace Roadkill.Text.Parsers.Links
 			newPageName = AddDashesForMarkdownTitle(newPageName, false);
 
 			string customRegex = GetRegexForTitle(oldPageName);
-			Regex regex = new Regex(customRegex, RegexOptions.IgnoreCase);
+			var regex = new Regex(customRegex, RegexOptions.IgnoreCase);
 
 			return regex.Replace(text, (System.Text.RegularExpressions.Match match) =>
 			{

--- a/src/Roadkill.Text/Parsers/Markdig/MarkdigImageAndLinkWalker.cs
+++ b/src/Roadkill.Text/Parsers/Markdig/MarkdigImageAndLinkWalker.cs
@@ -25,7 +25,7 @@ namespace Roadkill.Text.Parsers.Markdig
 			foreach (MarkdownObject child in markdownObject.Descendants())
 			{
 				// LinkInline can be both an <img.. or a <a href="...">
-				LinkInline linkInline = child as LinkInline;
+				var linkInline = child as LinkInline;
 				if (linkInline != null)
 				{
 					EnsureAttributesInLink(linkInline);
@@ -168,7 +168,7 @@ namespace Roadkill.Text.Parsers.Markdig
 		{
 			// Markdig TODO
 			// string linkID = altText.ToLowerInvariant();
-			HtmlImageTag args = new HtmlImageTag(url, url, altText, "");
+			var args = new HtmlImageTag(url, url, altText, "");
 			_imageDelegate(args);
 
 			return args;
@@ -176,7 +176,7 @@ namespace Roadkill.Text.Parsers.Markdig
 
 		private HtmlLinkTag InvokeLinkParsedEvent(string url, string text, string target)
 		{
-			HtmlLinkTag args = new HtmlLinkTag(url, url, text, target);
+			var args = new HtmlLinkTag(url, url, text, target);
 			_linkDelegate(args);
 
 			return args;

--- a/src/Roadkill.Text/Sanitizer/HtmlWhiteListProvider.cs
+++ b/src/Roadkill.Text/Sanitizer/HtmlWhiteListProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.Logging;
@@ -54,7 +54,7 @@ namespace Roadkill.Text.Sanitizer
 			}
 		}
 
-		internal HtmlWhiteListSettings CreateDefaultWhiteList()
+		internal static HtmlWhiteListSettings CreateDefaultWhiteList()
 		{
 			var allowedElements = new List<string>()
 			{

--- a/src/Roadkill.Text/Sanitizer/HtmlWhiteListSettings.cs
+++ b/src/Roadkill.Text/Sanitizer/HtmlWhiteListSettings.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Roadkill.Text.Sanitizer
 {

--- a/src/Roadkill.Text/TextMiddleware/CustomTokenMiddleware.cs
+++ b/src/Roadkill.Text/TextMiddleware/CustomTokenMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using Roadkill.Text.CustomTokens;
+using Roadkill.Text.CustomTokens;
 using Roadkill.Text.Models;
 
 namespace Roadkill.Text.TextMiddleware
@@ -14,6 +14,11 @@ namespace Roadkill.Text.TextMiddleware
 
 		public override PageHtml Invoke(PageHtml pageHtml)
 		{
+			if (pageHtml == null)
+			{
+				return null;
+			}
+
 			pageHtml.Html = _customTokenParser.ReplaceTokensAfterParse(pageHtml.Html);
 			return pageHtml;
 		}

--- a/src/Roadkill.Text/TextMiddleware/HarmfulTagMiddleware.cs
+++ b/src/Roadkill.Text/TextMiddleware/HarmfulTagMiddleware.cs
@@ -10,12 +10,12 @@ namespace Roadkill.Text.TextMiddleware
 
 		public HarmfulTagMiddleware(IHtmlSanitizerFactory htmlSanitizerFactory)
 		{
-			_sanitizer = htmlSanitizerFactory.CreateHtmlSanitizer();
+			_sanitizer = htmlSanitizerFactory?.CreateHtmlSanitizer();
 		}
 
 		public override PageHtml Invoke(PageHtml pageHtml)
 		{
-			if (_sanitizer != null)
+			if (_sanitizer != null && pageHtml != null)
 			{
 				pageHtml.Html = _sanitizer.Sanitize(pageHtml.Html);
 			}

--- a/src/Roadkill.Text/TextMiddleware/MarkupParserMiddleware.cs
+++ b/src/Roadkill.Text/TextMiddleware/MarkupParserMiddleware.cs
@@ -1,11 +1,11 @@
-﻿using Roadkill.Text.Models;
+using Roadkill.Text.Models;
 using Roadkill.Text.Parsers;
 
 namespace Roadkill.Text.TextMiddleware
 {
 	public class MarkupParserMiddleware : Middleware
 	{
-		private IMarkupParser _parser;
+		private readonly IMarkupParser _parser;
 
 		public MarkupParserMiddleware(IMarkupParser parser)
 		{


### PR DESCRIPTION
An initial round of code cleanup activities, namely
- removal of unused usings
- simplification of collection declarations
- use of var where types are obvious
- use of defined types in places where types are less obvious
- simplification of usings
- replacement of async void with async Task for tests to avoid deprecation issues