### PR TITLE
Add categories and associate pages to a category

### DIFF
--- a/src/Roadkill.Api.Common/Request/CategoryRequest.cs
+++ b/src/Roadkill.Api.Common/Request/CategoryRequest.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Roadkill.Api.Common.Request
+{
+	/// <summary>
+	/// Represents category information in Roadkill.
+	/// </summary>
+	public class CategoryRequest
+	{
+		/// <summary>
+		/// The unique Id of the category. This is generated on the server.
+		/// </summary>
+		public int Id { get; set; }
+
+		/// <summary>
+		/// The title of the category.
+		/// </summary>
+		[Required]
+		public string Title { get; set; }
+
+		/// <summary>
+		/// An optional description for the category
+		/// </summary>
+		public string Description { get; set; }
+	}
+}

--- a/src/Roadkill.Api.Common/Request/PageRequest.cs
+++ b/src/Roadkill.Api.Common/Request/PageRequest.cs
@@ -10,7 +10,7 @@ namespace Roadkill.Api.Common.Request
 	public class PageRequest
 	{
 		/// <summary>
-		/// The unique JwtToken of the page. This is generated on the server.
+		/// The unique Id of the page. This is generated on the server.
 		/// </summary>
 		public int Id { get; set; }
 

--- a/src/Roadkill.Api.Common/Request/PageRequest.cs
+++ b/src/Roadkill.Api.Common/Request/PageRequest.cs
@@ -38,13 +38,13 @@ namespace Roadkill.Api.Common.Request
 
 		/// <summary>
 		/// The user who last modified the page. If the page has
-		/// note been modified yet, this will match the CreatedBy property.
+		/// not been modified yet, this will match the CreatedBy property.
 		/// </summary>
 		public string LastModifiedBy { get; set; }
 
 		/// <summary>
 		/// The date the page was last modified on. If the page has
-		/// note been modified yet, this will match the creation date.
+		/// not been modified yet, this will match the creation date.
 		/// </summary>
 		public DateTime LastModifiedOn { get; set; }
 
@@ -59,5 +59,10 @@ namespace Roadkill.Api.Common.Request
 		/// </summary>
 		[Required]
 		public string Tags { get; set; }
+
+		/// <summary>
+		/// The Id for the Category the page is associated with.
+		/// </summary>
+		public int? CategoryId { get; set; }
 	}
 }

--- a/src/Roadkill.Api.Common/Response/CategoryResponse.cs
+++ b/src/Roadkill.Api.Common/Response/CategoryResponse.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+using AutoMapper;
+using Roadkill.Core.Entities;
+
+namespace Roadkill.Api.Common.Response
+{
+	/// <summary>
+	/// Represents page information in Roadkill.
+	/// </summary>
+	[AutoMap(typeof(Category))]
+	public class CategoryResponse
+	{
+		/// <summary>
+		/// The unique Id of the category. This is generated on the server.
+		/// </summary>
+		public int Id { get; set; }
+
+		/// <summary>
+		/// The title of the category.
+		/// </summary>
+		[Required]
+		public string Title { get; set; }
+
+		/// <summary>
+		/// An optional description for the category
+		/// </summary>
+		public string Description { get; set; }
+	}
+}

--- a/src/Roadkill.Api.Common/Response/PageResponse.cs
+++ b/src/Roadkill.Api.Common/Response/PageResponse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using AutoMapper;
@@ -60,7 +60,7 @@ namespace Roadkill.Api.Common.Response
 		public bool IsLocked { get; set; }
 
 		/// <summary>
-		/// The list of tags, comma seperated, for the page.
+		/// The list of tags, comma separated, for the page.
 		/// </summary>
 		[Required]
 		[Ignore]
@@ -71,5 +71,11 @@ namespace Roadkill.Api.Common.Response
 		/// </summary>
 		[Ignore]
 		public IEnumerable<string> TagList { get; set; }
+
+		/// <summary>
+		/// The Category the page is associated with.
+		/// </summary>
+		[Ignore]
+		public Category Category { get; set; }
 	}
 }

--- a/src/Roadkill.Api.Common/Response/PageResponse.cs
+++ b/src/Roadkill.Api.Common/Response/PageResponse.cs
@@ -14,7 +14,7 @@ namespace Roadkill.Api.Common.Response
 	public class PageResponse
 	{
 		/// <summary>
-		/// The unique JwtToken of the page. This is generated on the server.
+		/// The unique Id of the page. This is generated on the server.
 		/// </summary>
 		public int Id { get; set; }
 

--- a/src/Roadkill.Api/Authorization/Policies/PolicyNames.cs
+++ b/src/Roadkill.Api/Authorization/Policies/PolicyNames.cs
@@ -24,6 +24,10 @@ namespace Roadkill.Api.Authorization.Policies
 
 		public const string MarkdownUpdateLinks = nameof(MarkdownUpdateLinks);
 
+		public const string AddCategory = nameof(AddCategory);
+		public const string UpdateCategory = nameof(UpdateCategory);
+		public const string DeleteCategory = nameof(DeleteCategory);
+
 		public static IEnumerable<string> AllPolicies => new List<string>()
 		{
 			FindUsers,
@@ -42,7 +46,11 @@ namespace Roadkill.Api.Authorization.Policies
 
 			RenameTag,
 
-			MarkdownUpdateLinks
+			MarkdownUpdateLinks,
+
+			AddCategory,
+			UpdateCategory,
+			DeleteCategory
 		};
 	}
 }

--- a/src/Roadkill.Api/Authorization/Roles/EditorRoleDefinition.cs
+++ b/src/Roadkill.Api/Authorization/Roles/EditorRoleDefinition.cs
@@ -11,7 +11,9 @@ namespace Roadkill.Api.Authorization.Roles
 		private readonly List<string> _availablePolicies = new()
 		{
 			PolicyNames.AddPage,
-			PolicyNames.UpdatePage
+			PolicyNames.UpdatePage,
+			PolicyNames.AddCategory,
+			PolicyNames.UpdateCategory
 		};
 
 		public bool ContainsPolicy(string policyName)

--- a/src/Roadkill.Api/Controllers/CategoryController.cs
+++ b/src/Roadkill.Api/Controllers/CategoryController.cs
@@ -2,8 +2,13 @@ using Microsoft.AspNetCore.Authorization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Roadkill.Api.Common.Response;
+using Roadkill.Api.ObjectConverters;
 using Roadkill.Core.Entities;
 using Roadkill.Core.Repositories;
+using System.Collections.Generic;
+using System.Linq;
+using Roadkill.Api.Authorization.Policies;
+using Roadkill.Api.Common.Request;
 
 namespace Roadkill.Api.Controllers
 {
@@ -38,5 +43,75 @@ namespace Roadkill.Api.Controllers
 
 			return _categoryObjectsConverter.ConvertToCategoryResponse(category);
 		}
+
+		/// <summary>
+		/// Retrieves all categories in the Roadkill database.
+		/// </summary>
+		/// <returns>All the categories in the database.
+		/// </returns>
+		[HttpGet]
+		[Route(nameof(AllCategories))]
+		[AllowAnonymous]
+		public async Task<ActionResult<IEnumerable<CategoryResponse>>> AllCategories()
+		{
+			IEnumerable<Category> allCategories = await _categoryRepository.AllCategoriesAsync();
+			return Ok(allCategories.Select(_categoryObjectsConverter.ConvertToCategoryResponse));
+		}
+
+		/// <summary>
+		/// Add a category to the database using the provided information. 
+		/// </summary>
+		/// <param name="categoryRequest">The category information to add.</param>
+		/// <returns>A 202 HTTP status with the newly created category, with its generated ID populated.</returns>
+		[HttpPost]
+		[Authorize(Policy = PolicyNames.AddCategory)]
+		public async Task<ActionResult<PageResponse>> Add([FromBody] CategoryRequest categoryRequest)
+		{
+			Category category = _categoryObjectsConverter.ConvertToCategory(categoryRequest);
+			if (category == null)
+			{
+				//TODO: Not Found is a really shit return status if the convert has failed
+				return NotFound();
+			}
+
+			Category newCategory = await _categoryRepository.AddNewCategoryAsync(category);
+			CategoryResponse response = _categoryObjectsConverter.ConvertToCategoryResponse(newCategory);
+
+			return CreatedAtAction(nameof(Add), nameof(CategoryController), response);
+		}
+
+		/// <summary>
+		/// Updates an existing category in the database.
+		/// </summary>
+		/// <param name="categoryRequest">The category details to update, which should include the category id.</param>
+		/// <returns>The updated category details, or a 404 not found if the existing category cannot be found</returns>
+		[HttpPut]
+		[Authorize(Policy = PolicyNames.UpdateCategory)]
+		public async Task<ActionResult<CategoryResponse>> Update(CategoryRequest categoryRequest)
+		{
+			Category category = _categoryObjectsConverter.ConvertToCategory(categoryRequest);
+			if (category == null)
+			{
+				// again, a kinda shit response
+				return NotFound();
+			}
+
+			await _categoryRepository.UpdateExistingAsync(category);
+			return NoContent();
+		}
+
+		/// <summary>
+		/// Deletes an existing category from the database. This is an administrator-only action.
+		/// </summary>
+		/// <param name="categoryId">The id of the category to remove.</param>
+		/// <returns>A 204 if the category successfully deleted.</returns>
+		[HttpDelete]
+		[Authorize(Policy = PolicyNames.DeleteCategory)]
+		public async Task<ActionResult<string>> Delete(int categoryId)
+		{
+			await _categoryRepository.DeleteCategoryAsync(categoryId);
+			return NoContent();
+		}
+
 	}
 }

--- a/src/Roadkill.Api/Controllers/CategoryController.cs
+++ b/src/Roadkill.Api/Controllers/CategoryController.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Roadkill.Api.Common.Response;
+using Roadkill.Core.Entities;
+using Roadkill.Core.Repositories;
+
+namespace Roadkill.Api.Controllers
+{
+	public class CategoryController : ControllerBase
+	{
+		private readonly ICategoryRepository _categoryRepository;
+		private readonly ICategoryObjectsConverter _categoryObjectsConverter;
+
+		public CategoryController(
+			ICategoryRepository categoryRepository,
+			)
+		{
+			_categoryRepository = categoryRepository;
+		}
+
+		/// <summary>
+		/// Gets a single category by its ID.
+		/// </summary>
+		/// <param name="id">The unique ID of the category to retrieve.</param>
+		/// <returns>The category information, or a 404 not found if the category cannot be found.
+		/// </returns>
+		[HttpGet]
+		[AllowAnonymous]
+		[Route("{id}")]
+		public async Task<ActionResult<CategoryResponse>> Get(int id)
+		{
+			Category category = await _categoryRepository.GetCategoryByIdAsync(id);
+			if (category == null)
+			{
+				return NotFound();
+			}
+
+			return _categoryObjectsConverter.ConvertToCategoryResponse(category);
+		}
+	}
+}

--- a/src/Roadkill.Api/Controllers/CategoryController.cs
+++ b/src/Roadkill.Api/Controllers/CategoryController.cs
@@ -9,9 +9,18 @@ using System.Collections.Generic;
 using System.Linq;
 using Roadkill.Api.Authorization.Policies;
 using Roadkill.Api.Common.Request;
+using Asp.Versioning;
+using Roadkill.Api.Authorization.Roles;
 
 namespace Roadkill.Api.Controllers
 {
+	/// <summary>
+	/// Actions related to categories in the wiki, such as creation and retrieval.
+	/// </summary>
+	[ApiController]
+	[ApiVersion("3")]
+	[Route("v{version:apiVersion}/[controller]")]
+	[AuthorizeWithBearer]
 	public class CategoryController : ControllerBase
 	{
 		private readonly ICategoryRepository _categoryRepository;
@@ -19,9 +28,10 @@ namespace Roadkill.Api.Controllers
 
 		public CategoryController(
 			ICategoryRepository categoryRepository,
-			)
+			ICategoryObjectsConverter categoryObjectsConverter)
 		{
 			_categoryRepository = categoryRepository;
+			_categoryObjectsConverter = categoryObjectsConverter;
 		}
 
 		/// <summary>
@@ -70,7 +80,6 @@ namespace Roadkill.Api.Controllers
 			Category category = _categoryObjectsConverter.ConvertToCategory(categoryRequest);
 			if (category == null)
 			{
-				//TODO: Not Found is a really shit return status if the convert has failed
 				return NotFound();
 			}
 
@@ -92,7 +101,6 @@ namespace Roadkill.Api.Controllers
 			Category category = _categoryObjectsConverter.ConvertToCategory(categoryRequest);
 			if (category == null)
 			{
-				// again, a kinda shit response
 				return NotFound();
 			}
 
@@ -112,6 +120,5 @@ namespace Roadkill.Api.Controllers
 			await _categoryRepository.DeleteCategoryAsync(categoryId);
 			return NoContent();
 		}
-
 	}
 }

--- a/src/Roadkill.Api/Controllers/PagesController.cs
+++ b/src/Roadkill.Api/Controllers/PagesController.cs
@@ -25,13 +25,16 @@ namespace Roadkill.Api.Controllers
 	{
 		// [ApiController] adds [FromBody] by default and model validation
 		private readonly IPageRepository _pageRepository;
+		//private readonly ICategoryRepository _categoryRepository;
 		private readonly IPageObjectsConverter _pageObjectsConverter;
 
 		public PagesController(
 			IPageRepository pageRepository,
+			//ICategoryRepository categoryRepository,
 			IPageObjectsConverter pageObjectsConverter)
 		{
 			_pageRepository = pageRepository;
+			//_categoryRepository = categoryRepository;
 			_pageObjectsConverter = pageObjectsConverter;
 		}
 

--- a/src/Roadkill.Api/Controllers/PagesController.cs
+++ b/src/Roadkill.Api/Controllers/PagesController.cs
@@ -25,12 +25,10 @@ namespace Roadkill.Api.Controllers
 	{
 		// [ApiController] adds [FromBody] by default and model validation
 		private readonly IPageRepository _pageRepository;
-		//private readonly ICategoryRepository _categoryRepository;
 		private readonly IPageObjectsConverter _pageObjectsConverter;
 
 		public PagesController(
 			IPageRepository pageRepository,
-			//ICategoryRepository categoryRepository,
 			IPageObjectsConverter pageObjectsConverter)
 		{
 			_pageRepository = pageRepository;
@@ -87,6 +85,22 @@ namespace Roadkill.Api.Controllers
 			IEnumerable<Page> pagesCreatedBy = await _pageRepository.FindPagesCreatedByAsync(username);
 
 			IEnumerable<PageResponse> models = pagesCreatedBy.Select(_pageObjectsConverter.ConvertToPageResponse);
+			return Ok(models);
+		}
+
+		/// <summary>
+		/// Retrieves all pages for a specific category
+		/// </summary>
+		/// <param name="categoryId">The Id of the Category that pages are associated with</param>
+		/// <returns>Meta information for all the pages associated with the specified Category</returns>
+		[HttpGet]
+		[Route(nameof(PagesForCategory))]
+		[AllowAnonymous]
+		public async Task<ActionResult<IEnumerable<PageResponse>>> PagesForCategory(int categoryId)
+		{
+			IEnumerable<Page> pagesForCategory = await _pageRepository.FindPagesByCategory(categoryId);
+
+			IEnumerable<PageResponse> models = pagesForCategory.Select(_pageObjectsConverter.ConvertToPageResponse);
 			return Ok(models);
 		}
 

--- a/src/Roadkill.Api/ObjectConverters/CategoryObjectsConverter.cs
+++ b/src/Roadkill.Api/ObjectConverters/CategoryObjectsConverter.cs
@@ -10,7 +10,7 @@ namespace Roadkill.Api.ObjectConverters
 	{
 		CategoryResponse ConvertToCategoryResponse(Category category);
 
-		Category ConvertToToCategory(CategoryRequest request);
+		Category ConvertToCategory(CategoryRequest request);
 	}
 
 	public class CategoryObjectsConverter : ICategoryObjectsConverter
@@ -33,7 +33,7 @@ namespace Roadkill.Api.ObjectConverters
 			return categoryResponse;
 		}
 
-		public Category ConvertToToCategory(CategoryRequest request)
+		public Category ConvertToCategory(CategoryRequest request)
 		{
 			return _mapper.Map<Category>(request);
 		}

--- a/src/Roadkill.Api/ObjectConverters/CategoryObjectsConverter.cs
+++ b/src/Roadkill.Api/ObjectConverters/CategoryObjectsConverter.cs
@@ -1,0 +1,41 @@
+using System;
+using AutoMapper;
+using Roadkill.Api.Common.Request;
+using Roadkill.Api.Common.Response;
+using Roadkill.Core.Entities;
+
+namespace Roadkill.Api.ObjectConverters
+{
+	public interface ICategoryObjectsConverter
+	{
+		CategoryResponse ConvertToCategoryResponse(Category category);
+
+		Category ConvertToToCategory(CategoryRequest request);
+	}
+
+	public class CategoryObjectsConverter : ICategoryObjectsConverter
+	{
+		private readonly IMapper _mapper;
+
+		public CategoryObjectsConverter(IMapper mapper)
+		{
+			_mapper = mapper;
+		}
+
+		public CategoryResponse ConvertToCategoryResponse(Category category)
+		{
+			if (category is null)
+			{
+				throw new ArgumentNullException(nameof(category));
+			}
+
+			var categoryResponse = _mapper.Map<CategoryResponse>(category);
+			return categoryResponse;
+		}
+
+		public Category ConvertToToCategory(CategoryRequest request)
+		{
+			return _mapper.Map<Category>(request);
+		}
+	}
+}

--- a/src/Roadkill.Api/ObjectConverters/CategoryObjectsConverter.cs
+++ b/src/Roadkill.Api/ObjectConverters/CategoryObjectsConverter.cs
@@ -35,7 +35,16 @@ namespace Roadkill.Api.ObjectConverters
 
 		public Category ConvertToCategory(CategoryRequest request)
 		{
-			return _mapper.Map<Category>(request);
+			try
+			{
+				return _mapper.Map<Category>(request);
+
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+				throw;
+			}
 		}
 	}
 }

--- a/src/Roadkill.Api/ObjectConverters/MappingProfile.cs
+++ b/src/Roadkill.Api/ObjectConverters/MappingProfile.cs
@@ -17,6 +17,9 @@ namespace Roadkill.Api.ObjectConverters
 			CreateMap<Page, PageResponse>();
 			CreateMap<RoadkillIdentityUser, UserResponse>();
 			CreateMap<PageVersion, PageVersionResponse>();
+
+			CreateMap<CategoryRequest, Category>();
+			CreateMap<Category, CategoryResponse>();
 		}
 	}
 }

--- a/src/Roadkill.Core/Entities/Category.cs
+++ b/src/Roadkill.Core/Entities/Category.cs
@@ -1,0 +1,12 @@
+namespace Roadkill.Core.Entities
+{
+	public class Category
+	{
+		public int Id { get; set; }
+
+		public string Title { get; set; }
+
+		public string Description { get; set; }
+
+	}
+}

--- a/src/Roadkill.Core/Entities/Page.cs
+++ b/src/Roadkill.Core/Entities/Page.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Roadkill.Core.Entities
 {
@@ -19,5 +19,7 @@ namespace Roadkill.Core.Entities
 		public string Tags { get; set; }
 
 		public bool IsLocked { get; set; }
+
+		public int? CategoryId { get; set; }
 	}
 }

--- a/src/Roadkill.Core/Repositories/CategoryRepository.cs
+++ b/src/Roadkill.Core/Repositories/CategoryRepository.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Marten;
+using Roadkill.Core.Entities;
+
+namespace Roadkill.Core.Repositories
+{
+	public interface ICategoryRepository
+	{
+		Task<Category> AddNewCategoryAsync(Category category);
+
+		Task<Category> UpdateExistingAsync(Category category);
+
+		Task<IEnumerable<Category>> AllCategoriesAsync();
+
+		Task<Category> GetCategoryByIdAsync(int id);
+
+		Task DeleteCategoryAsync(int categoryId);
+	}
+
+	public class CategoryRepository : ICategoryRepository
+	{
+		private readonly IDocumentStore _store;
+
+		public CategoryRepository(IDocumentStore store)
+		{
+			_store = store ?? throw new ArgumentNullException(nameof(store));
+		}
+
+		public async Task<Category> AddNewCategoryAsync(Category category)
+		{
+			if (category is null)
+			{
+				throw new ArgumentNullException(nameof(category));
+			}
+
+			category.Id = 0; //reset so its autoincremented
+
+			await using var session = _store.LightweightSession();
+			session.Store(category);
+
+			await session.SaveChangesAsync();
+			return category;
+		}
+
+		public async Task<IEnumerable<Category>> AllCategoriesAsync()
+		{
+			await using var session = _store.QuerySession();
+			return await session
+				.Query<Category>()
+				.ToListAsync();
+		}
+
+		public async Task<Category> GetCategoryByIdAsync(int id)
+		{
+			await using var session = _store.QuerySession();
+			return await session
+				.Query<Category>()
+				.FirstOrDefaultAsync(x => x.Id == id);
+		}
+
+		public async Task<Category> UpdateExistingAsync(Category category)
+		{
+			await using var session = _store.LightweightSession();
+			session.Update(category);
+
+			await session.SaveChangesAsync();
+			return category;
+		}
+
+		public async Task DeleteCategoryAsync(int categoryId)
+		{
+			await using var session = _store.LightweightSession();
+			session.Delete<Category>(categoryId);
+
+			//TODO: FInd any Page with the Category and reset to null
+			//		Alternatively - should that be done at a 'higher' level?
+
+			await session.SaveChangesAsync();
+		}
+
+		public async Task DeleteAllCategoriesAsync()
+		{
+			await using var session = _store.LightweightSession();
+			session.DeleteWhere<Category>(x => true);
+
+			//TODO: Update the Pages to remove the Categories
+
+			await session.SaveChangesAsync();
+		}
+
+		public void Wipe()
+		{
+			try
+			{
+				_store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Category));
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+			}
+		}
+	}
+}

--- a/src/Roadkill.Core/Repositories/PageRepository.cs
+++ b/src/Roadkill.Core/Repositories/PageRepository.cs
@@ -25,6 +25,8 @@ namespace Roadkill.Core.Repositories
 
 		Task<IEnumerable<Page>> FindPagesContainingTagAsync(string tag);
 
+		Task<IEnumerable<Page>> FindPagesByCategory(int categoryId);
+
 		Task<Page> GetPageByIdAsync(int id);
 
 		// Case insensitive search by page title
@@ -110,6 +112,15 @@ namespace Roadkill.Core.Repositories
 			return await session
 				.Query<Page>()
 				.Where(x => x.Tags.Contains(tag))
+				.ToListAsync();
+		}
+
+		public async Task<IEnumerable<Page>> FindPagesByCategory(int categoryId)
+		{
+			await using var session = _store.QuerySession();
+			return await session
+				.Query<Page>()
+				.Where(x => x.CategoryId == categoryId)
 				.ToListAsync();
 		}
 

--- a/src/Roadkill.Tests.Integration/Core/Repositories/CategoryRepositoryTests.cs
+++ b/src/Roadkill.Tests.Integration/Core/Repositories/CategoryRepositoryTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using Marten;
+using Roadkill.Core.Entities;
+using Roadkill.Core.Repositories;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace Roadkill.Tests.Integration.Core.Repositories
+{
+	public class CategoryRepositoryTests
+	{
+		private readonly ITestOutputHelper _outputHelper;
+		private readonly Fixture _fixture;
+
+		public CategoryRepositoryTests(ITestOutputHelper outputHelperHelper)
+		{
+			_outputHelper = outputHelperHelper;
+			_fixture = new Fixture();
+			IDocumentStore documentStore =
+				DocumentStoreManager.GetMartenDocumentStore(typeof(CategoryRepositoryTests), outputHelperHelper);
+
+			try
+			{
+				new PageRepository(documentStore).Wipe();
+			}
+			catch (Exception e)
+			{
+				_outputHelper.WriteLine(GetType().Name + " caught: " + e.ToString());
+			}
+		}
+
+		public CategoryRepository CreateRepository()
+		{
+			IDocumentStore documentStore =
+				DocumentStoreManager.GetMartenDocumentStore(typeof(CategoryRepositoryTests), _outputHelper);
+
+			return new CategoryRepository(documentStore);
+		}
+
+
+
+		[Fact]
+		public async Task AddNewCategory_should_add_category_and_increment_id()
+		{
+			// given a new Category to add to the repository
+			string title = "Testing";
+			string description = "A TEsting Category";
+
+			CategoryRepository repository = CreateRepository();
+
+			Category category = _fixture.Create<Category>();
+			category.Title = title;
+			category.Description = description;
+
+			// when the Category is saved to the repository
+			var returnedCategory = await repository.AddNewCategoryAsync(category);
+
+			// then the returned category Id has been set to a non zero value
+			returnedCategory.Id.ShouldBeGreaterThan(0);
+
+			// and the category has been saved to the repository
+			var storedCategory = await repository.GetCategoryByIdAsync(returnedCategory.Id);
+
+			storedCategory.ShouldNotBeNull();
+		}
+
+		[Fact]
+		public async Task DeleteCategory_should_delete_specific_page()
+		{
+			// given a Category is known to exist
+			CategoryRepository repository = CreateRepository();
+
+			var categoryToDelete = _fixture.Create<Category>();
+			await repository.AddNewCategoryAsync(categoryToDelete);
+
+			// when the known Category is deleted
+			await repository.DeleteCategoryAsync(categoryToDelete.Id);
+
+			// then the Category has been deleted
+			var deletedCategory = await repository.GetCategoryByIdAsync(categoryToDelete.Id);
+			deletedCategory.ShouldBeNull();
+		}
+
+		[Fact]
+		public async Task DeleteAlCategories_should_clear_categories()
+		{
+			// given a set of known Categories exist in the data store
+			CategoryRepository repository = CreateRepository();
+			CreateTenCategories(repository);
+
+			// when all categories are deleted
+			await repository.DeleteAllCategoriesAsync();
+
+			// then
+			IEnumerable<Category> allCategories = await repository.AllCategoriesAsync();
+			allCategories.ShouldBeEmpty();
+		}
+
+		[Fact]
+		public async Task UpdateExisting_should_save_changes()
+		{
+			// given
+			CategoryRepository repository = CreateRepository();
+			List<Category> categories = CreateTenCategories(repository);
+
+			Category expectedCategory = categories[0];
+			expectedCategory.Description = "Updated Description for testing";
+
+			// when
+			await repository.UpdateExistingAsync(expectedCategory);
+
+			// then
+			Category actualCategory = await repository.GetCategoryByIdAsync(expectedCategory.Id);
+			actualCategory.ShouldBeEquivalent(expectedCategory);
+		}
+
+		private List<Category> CreateTenCategories(CategoryRepository repository, List<Category> categories = null)
+		{
+			categories ??= _fixture.CreateMany<Category>(10).ToList();
+
+			var newCategories = new List<Category>();
+
+			foreach (Category category in categories)
+			{
+				Category newCategory = repository.AddNewCategoryAsync(category).GetAwaiter().GetResult();
+				newCategories.Add(newCategory);
+			}
+
+			return newCategories;
+		}
+	}
+}

--- a/src/Roadkill.Tests.Integration/Core/Repositories/CategoryRepositoryTests.cs
+++ b/src/Roadkill.Tests.Integration/Core/Repositories/CategoryRepositoryTests.cs
@@ -43,8 +43,6 @@ namespace Roadkill.Tests.Integration.Core.Repositories
 			return new CategoryRepository(documentStore);
 		}
 
-
-
 		[Fact]
 		public async Task AddNewCategory_should_add_category_and_increment_id()
 		{

--- a/src/Roadkill.Tests.Integration/Roadkill.Tests.Integration.csproj
+++ b/src/Roadkill.Tests.Integration/Roadkill.Tests.Integration.csproj
@@ -34,10 +34,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Core" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Update="Microsoft.CodeQuality.Analyzers" Version="3.3.2" />
     <PackageReference Update="Microsoft.NetCore.Analyzers" Version="3.3.2" />
     <PackageReference Update="OpenCover" Version="4.7.1221" />

--- a/src/Roadkill.Tests.Unit/Api/Controllers/PagesControllerTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/Controllers/PagesControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -19,10 +19,11 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 {
 	public class PagesControllerTests
 	{
-		private IPageRepository _pageRepositoryMock;
-		private IPageObjectsConverter _viewObjectsConverterMock;
-		private PagesController _pagesController;
-		private Fixture _fixture;
+		private readonly IPageRepository _pageRepositoryMock;
+		private readonly IPageObjectsConverter _viewObjectsConverterMock;
+		private readonly PagesController _pagesController;
+		private readonly Fixture _fixture;
+		private readonly ICategoryRepository _categoryRepositoryMock;
 
 		public PagesControllerTests()
 		{
@@ -30,6 +31,7 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 
 			_pageRepositoryMock = Substitute.For<IPageRepository>();
 			_viewObjectsConverterMock = Substitute.For<IPageObjectsConverter>();
+			_categoryRepositoryMock = Substitute.For<ICategoryRepository>();
 
 			_viewObjectsConverterMock
 				.ConvertToPageResponse(Arg.Any<Page>())
@@ -51,6 +53,10 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 					};
 				});
 
+			_categoryRepositoryMock
+				.GetCategoryByIdAsync(Arg.Any<int>())
+				.Returns(new Category { Id = 1001, Description = "Test Category", Title = "Testing" });
+			
 			_pagesController = new PagesController(_pageRepositoryMock, _viewObjectsConverterMock);
 		}
 
@@ -109,10 +115,15 @@ namespace Roadkill.Tests.Unit.Api.Controllers
 			// given
 			Page expectedPage = _fixture.Create<Page>();
 			int id = expectedPage.Id;
+			int categoryId = expectedPage.CategoryId!.Value;
 
 			_pageRepositoryMock
 				.GetPageByIdAsync(id)
 				.Returns(expectedPage);
+
+			_categoryRepositoryMock
+				.GetCategoryByIdAsync(categoryId)
+				.Returns(new Category { Id = categoryId, Description = "Test Category", Title = "Testing" });
 
 			// when
 			ActionResult<PageResponse> actionResult = await _pagesController.Get(id);

--- a/src/Roadkill.Tests.Unit/Api/ObjectConverters/PageObjectsConverterTests.cs
+++ b/src/Roadkill.Tests.Unit/Api/ObjectConverters/PageObjectsConverterTests.cs
@@ -25,7 +25,7 @@ namespace Roadkill.Tests.Unit.Api.ObjectConverters
 			var provider = services.BuildServiceProvider();
 			var mapper = provider.GetService<IMapper>();
 
-			_converter = new PageObjectsConverter(mapper);
+			_converter = new PageObjectsConverter(mapper,null);
 		}
 
 		[Fact]


### PR DESCRIPTION
Introducing Categories to allow for the grouping of Pages to a specific Category, e.g. two pages grouped together under the category 'Linux Administration'

Linux Administration
    - Debugging shell scripts
    - Upgrading centos

This change also fixes a few small typos in comments